### PR TITLE
Add Forgejo bootstrap and linking

### DIFF
--- a/src/forgejo-bootstrap.test.ts
+++ b/src/forgejo-bootstrap.test.ts
@@ -1,0 +1,183 @@
+import {
+  createIntegrationBindingId,
+  createProjectId,
+  createTaskId,
+  type IntegrationBinding,
+  type TaskPushPayload,
+} from "@todu/core";
+
+import { createInMemoryForgejoIssueClient } from "@/forgejo-client";
+import { parseForgejoIssueExternalId } from "@/forgejo-ids";
+import { createInMemoryForgejoItemLinkStore } from "@/forgejo-links";
+import { bootstrapForgejoIssuesToTasks, bootstrapTasksToForgejoIssues } from "@/forgejo-bootstrap";
+
+const binding: IntegrationBinding = {
+  id: createIntegrationBindingId("binding-1"),
+  provider: "forgejo",
+  projectId: createProjectId("project-1"),
+  targetKind: "repository",
+  targetRef: "erik/todu-forgejo-plugin-test",
+  strategy: "bidirectional",
+  enabled: true,
+  createdAt: "2026-03-12T00:00:00.000Z",
+  updatedAt: "2026-03-12T00:00:00.000Z",
+};
+
+const target = {
+  baseUrl: "https://forgejo.caradoc.com",
+  apiBaseUrl: "https://forgejo.caradoc.com/api/v1",
+  owner: "erik",
+  repo: "todu-forgejo-plugin-test",
+};
+
+describe("forgejo bootstrap", () => {
+  it("imports open issues and creates durable links", async () => {
+    const issueClient = createInMemoryForgejoIssueClient();
+    const linkStore = createInMemoryForgejoItemLinkStore();
+
+    issueClient.seedIssues(target, [
+      {
+        number: 1,
+        externalId: "https://forgejo.caradoc.com/erik/todu-forgejo-plugin-test#1",
+        title: "Open issue",
+        body: "Imported body",
+        state: "open",
+        labels: ["bug"],
+        assignees: ["erik"],
+        createdAt: "2026-03-12T00:00:00.000Z",
+        updatedAt: "2026-03-12T00:00:00.000Z",
+      },
+      {
+        number: 2,
+        externalId: "https://forgejo.caradoc.com/erik/todu-forgejo-plugin-test#2",
+        title: "Closed issue",
+        state: "closed",
+        labels: [],
+        assignees: [],
+        createdAt: "2026-03-12T00:00:00.000Z",
+        updatedAt: "2026-03-12T00:00:00.000Z",
+      },
+    ]);
+
+    const result = await bootstrapForgejoIssuesToTasks({
+      binding,
+      baseUrl: target.baseUrl,
+      apiBaseUrl: target.apiBaseUrl,
+      owner: target.owner,
+      repo: target.repo,
+      issueClient,
+      linkStore,
+    });
+
+    expect(result.tasks).toHaveLength(1);
+    expect(result.tasks[0].externalId).toBe(
+      "https://forgejo.caradoc.com/erik/todu-forgejo-plugin-test#1"
+    );
+    expect(result.createdLinks).toHaveLength(1);
+    expect(linkStore.getByIssueNumber(binding.id, 1)?.externalId).toBe(
+      "https://forgejo.caradoc.com/erik/todu-forgejo-plugin-test#1"
+    );
+  });
+
+  it("exports active tasks to forgejo and assigns external ids and source urls", async () => {
+    const issueClient = createInMemoryForgejoIssueClient();
+    const linkStore = createInMemoryForgejoItemLinkStore();
+    const tasks: TaskPushPayload[] = [
+      {
+        id: createTaskId("task-1"),
+        title: "Create sync",
+        description: "Bootstrap this issue",
+        status: "active",
+        priority: "high",
+        projectId: binding.projectId,
+        labels: [],
+        assignees: [],
+        comments: [],
+        createdAt: "2026-03-12T00:00:00.000Z",
+        updatedAt: "2026-03-12T00:00:00.000Z",
+      },
+      {
+        id: createTaskId("task-2"),
+        title: "Ignore closed task",
+        status: "done",
+        priority: "medium",
+        projectId: binding.projectId,
+        labels: [],
+        assignees: [],
+        comments: [],
+        createdAt: "2026-03-12T00:00:00.000Z",
+        updatedAt: "2026-03-12T00:00:00.000Z",
+      },
+    ];
+
+    const result = await bootstrapTasksToForgejoIssues({
+      binding,
+      baseUrl: target.baseUrl,
+      apiBaseUrl: target.apiBaseUrl,
+      owner: target.owner,
+      repo: target.repo,
+      tasks,
+      issueClient,
+      linkStore,
+    });
+
+    expect(result.createdIssues).toHaveLength(1);
+    expect(result.createdLinks).toHaveLength(1);
+    expect(tasks[0].externalId).toBeDefined();
+    expect(tasks[0].sourceUrl).toBe(
+      "https://forgejo.caradoc.com/erik/todu-forgejo-plugin-test/issues/1"
+    );
+    expect(tasks[1].externalId).toBeUndefined();
+  });
+
+  it("links to existing matching external ids instead of creating duplicates", async () => {
+    const issueClient = createInMemoryForgejoIssueClient();
+    const linkStore = createInMemoryForgejoItemLinkStore();
+
+    issueClient.seedIssues(target, [
+      {
+        number: 7,
+        externalId: "https://forgejo.caradoc.com/erik/todu-forgejo-plugin-test#7",
+        title: "Existing issue",
+        state: "open",
+        labels: [],
+        assignees: [],
+        createdAt: "2026-03-12T00:00:00.000Z",
+        updatedAt: "2026-03-12T00:00:00.000Z",
+      },
+    ]);
+
+    const tasks: TaskPushPayload[] = [
+      {
+        id: createTaskId("task-1"),
+        title: "Reuse issue",
+        externalId: "https://forgejo.caradoc.com/erik/todu-forgejo-plugin-test#7",
+        status: "active",
+        priority: "medium",
+        projectId: binding.projectId,
+        labels: [],
+        assignees: [],
+        comments: [],
+        createdAt: "2026-03-12T00:00:00.000Z",
+        updatedAt: "2026-03-12T01:00:00.000Z",
+      },
+    ];
+
+    const result = await bootstrapTasksToForgejoIssues({
+      binding,
+      baseUrl: target.baseUrl,
+      apiBaseUrl: target.apiBaseUrl,
+      owner: target.owner,
+      repo: target.repo,
+      tasks,
+      issueClient,
+      linkStore,
+    });
+
+    expect(result.createdIssues).toHaveLength(0);
+    expect(result.createdLinks).toHaveLength(1);
+    expect(result.updatedIssues).toHaveLength(1);
+    expect(linkStore.getByTaskId(binding.id, tasks[0].id)?.issueNumber).toBe(7);
+    expect(parseForgejoIssueExternalId(tasks[0].externalId!).issueNumber).toBe(7);
+  });
+});

--- a/src/forgejo-bootstrap.ts
+++ b/src/forgejo-bootstrap.ts
@@ -1,0 +1,260 @@
+import type { ExternalTask, IntegrationBinding, TaskPushPayload } from "@todu/core";
+
+import {
+  createForgejoIssueSourceUrl,
+  type ForgejoIssue,
+  type ForgejoIssueClient,
+} from "@/forgejo-client";
+import { parseForgejoIssueExternalId } from "@/forgejo-ids";
+import {
+  createLinkFromIssue,
+  createLinkFromTask,
+  type ForgejoItemLink,
+  type ForgejoItemLinkStore,
+} from "@/forgejo-links";
+
+const TASK_BOOTSTRAP_EXPORT_STATUSES = new Set<TaskPushPayload["status"]>([
+  "active",
+  "inprogress",
+  "waiting",
+]);
+
+export interface ForgejoBootstrapImportResult {
+  tasks: ExternalTask[];
+  createdLinks: ForgejoItemLink[];
+}
+
+export interface ForgejoBootstrapTaskUpdate {
+  taskId: TaskPushPayload["id"];
+  externalId: string;
+  sourceUrl?: string;
+}
+
+export interface ForgejoBootstrapExportResult {
+  createdIssues: ForgejoIssue[];
+  updatedIssues: ForgejoIssue[];
+  createdLinks: ForgejoItemLink[];
+  taskUpdates: ForgejoBootstrapTaskUpdate[];
+}
+
+export async function bootstrapForgejoIssuesToTasks(input: {
+  binding: IntegrationBinding;
+  baseUrl: string;
+  apiBaseUrl: string;
+  owner: string;
+  repo: string;
+  issueClient: ForgejoIssueClient;
+  linkStore: ForgejoItemLinkStore;
+  since?: string;
+}): Promise<ForgejoBootstrapImportResult> {
+  const issues = await input.issueClient.listIssues(
+    {
+      baseUrl: input.baseUrl,
+      apiBaseUrl: input.apiBaseUrl,
+      owner: input.owner,
+      repo: input.repo,
+    },
+    input.since ? { since: input.since } : undefined
+  );
+
+  const tasks: ExternalTask[] = [];
+  const createdLinks: ForgejoItemLink[] = [];
+
+  for (const issue of issues) {
+    if (issue.isPullRequest) {
+      continue;
+    }
+
+    const existingLink = input.linkStore.getByIssueNumber(input.binding.id, issue.number);
+    if (!existingLink && issue.state !== "open") {
+      continue;
+    }
+
+    if (!existingLink) {
+      const createdLink = createLinkFromIssue({
+        binding: input.binding,
+        issue,
+        baseUrl: input.baseUrl,
+        owner: input.owner,
+        repo: input.repo,
+      });
+      input.linkStore.save(createdLink);
+      createdLinks.push(createdLink);
+    }
+
+    tasks.push({
+      externalId: issue.externalId,
+      priority: "medium",
+      title: issue.title,
+      description: issue.body,
+      status: issue.state === "closed" ? "done" : "active",
+      labels: [...issue.labels],
+      assignees: [...issue.assignees],
+      sourceUrl: issue.sourceUrl,
+      createdAt: issue.createdAt,
+      updatedAt: issue.updatedAt,
+      raw: issue,
+    });
+  }
+
+  return {
+    tasks,
+    createdLinks,
+  };
+}
+
+export async function bootstrapTasksToForgejoIssues(input: {
+  binding: IntegrationBinding;
+  baseUrl: string;
+  apiBaseUrl: string;
+  owner: string;
+  repo: string;
+  tasks: TaskPushPayload[];
+  issueClient: ForgejoIssueClient;
+  linkStore: ForgejoItemLinkStore;
+}): Promise<ForgejoBootstrapExportResult> {
+  const createdIssues: ForgejoIssue[] = [];
+  const updatedIssues: ForgejoIssue[] = [];
+  const createdLinks: ForgejoItemLink[] = [];
+  const taskUpdates: ForgejoBootstrapTaskUpdate[] = [];
+
+  const target = {
+    baseUrl: input.baseUrl,
+    apiBaseUrl: input.apiBaseUrl,
+    owner: input.owner,
+    repo: input.repo,
+  };
+
+  for (const task of input.tasks) {
+    const existingLink = input.linkStore.getByTaskId(input.binding.id, task.id);
+    if (existingLink) {
+      const existingIssue = await input.issueClient.getIssue(target, existingLink.issueNumber);
+      task.externalId = existingLink.externalId;
+      task.sourceUrl = existingIssue?.sourceUrl ?? task.sourceUrl;
+
+      if (shouldPushTaskUpdate(task, existingIssue)) {
+        const updatedIssue = await input.issueClient.updateIssue(target, existingLink.issueNumber, {
+          title: task.title,
+          body: task.description,
+        });
+        task.sourceUrl = updatedIssue.sourceUrl;
+        updatedIssues.push(updatedIssue);
+      }
+      continue;
+    }
+
+    const matchingExternalId = getMatchingExternalId(task, input.baseUrl, input.owner, input.repo);
+    if (matchingExternalId) {
+      const createdLink = createLinkFromTask({
+        binding: input.binding,
+        taskId: task.id,
+        baseUrl: input.baseUrl,
+        owner: input.owner,
+        repo: input.repo,
+        issueNumber: matchingExternalId.issueNumber,
+      });
+      task.externalId = createdLink.externalId;
+      task.sourceUrl ??= createForgejoIssueSourceUrl(target, matchingExternalId.issueNumber);
+      input.linkStore.save(createdLink);
+      createdLinks.push(createdLink);
+
+      const existingIssue = await input.issueClient.getIssue(
+        target,
+        matchingExternalId.issueNumber
+      );
+      if (shouldPushTaskUpdate(task, existingIssue)) {
+        const updatedIssue = await input.issueClient.updateIssue(
+          target,
+          matchingExternalId.issueNumber,
+          {
+            title: task.title,
+            body: task.description,
+          }
+        );
+        task.sourceUrl = updatedIssue.sourceUrl;
+        updatedIssues.push(updatedIssue);
+      }
+      continue;
+    }
+
+    if (!TASK_BOOTSTRAP_EXPORT_STATUSES.has(task.status)) {
+      continue;
+    }
+
+    const createdIssue = await input.issueClient.createIssue(target, {
+      title: task.title,
+      body: task.description,
+      state: "open",
+    });
+
+    createdIssues.push(createdIssue);
+
+    const createdLink = createLinkFromTask({
+      binding: input.binding,
+      taskId: task.id,
+      baseUrl: input.baseUrl,
+      owner: input.owner,
+      repo: input.repo,
+      issueNumber: createdIssue.number,
+    });
+    task.externalId = createdLink.externalId;
+    task.sourceUrl = createdIssue.sourceUrl;
+    input.linkStore.save(createdLink);
+    createdLinks.push(createdLink);
+    taskUpdates.push({
+      taskId: task.id,
+      externalId: createdLink.externalId,
+      sourceUrl: createdIssue.sourceUrl,
+    });
+  }
+
+  return {
+    createdIssues,
+    updatedIssues,
+    createdLinks,
+    taskUpdates,
+  };
+}
+
+function shouldPushTaskUpdate(task: TaskPushPayload, issue: ForgejoIssue | null): boolean {
+  if (!issue?.updatedAt) {
+    return true;
+  }
+
+  const taskUpdatedAt = Date.parse(task.updatedAt);
+  const issueUpdatedAt = Date.parse(issue.updatedAt);
+
+  if (Number.isNaN(taskUpdatedAt) || Number.isNaN(issueUpdatedAt)) {
+    return true;
+  }
+
+  return taskUpdatedAt >= issueUpdatedAt;
+}
+
+function getMatchingExternalId(
+  task: TaskPushPayload,
+  baseUrl: string,
+  owner: string,
+  repo: string
+): { issueNumber: number } | null {
+  if (!task.externalId) {
+    return null;
+  }
+
+  try {
+    const parsedExternalId = parseForgejoIssueExternalId(task.externalId);
+    if (
+      parsedExternalId.baseUrl !== baseUrl ||
+      parsedExternalId.owner !== owner ||
+      parsedExternalId.repo !== repo
+    ) {
+      return null;
+    }
+
+    return {
+      issueNumber: parsedExternalId.issueNumber,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/src/forgejo-client.ts
+++ b/src/forgejo-client.ts
@@ -1,5 +1,6 @@
 import type { ForgejoRepositoryTarget as ForgejoRepositoryRef } from "@/forgejo-binding";
 import type { ForgejoAuthType } from "@/forgejo-config";
+import { formatForgejoIssueExternalId } from "@/forgejo-ids";
 
 export interface ForgejoRepositoryTarget extends ForgejoRepositoryRef {
   baseUrl: string;
@@ -93,13 +94,6 @@ export interface ForgejoHttpClientOptions {
   fetchImpl?: typeof fetch;
 }
 
-export function formatForgejoIssueExternalId(
-  target: ForgejoRepositoryTarget,
-  issueNumber: number
-): string {
-  return `${target.baseUrl}/${target.owner}/${target.repo}#${issueNumber}`;
-}
-
 export function createForgejoIssueSourceUrl(
   target: ForgejoRepositoryTarget,
   issueNumber: number
@@ -187,7 +181,14 @@ export function createInMemoryForgejoIssueClient(): InMemoryForgejoIssueClient {
         issues.map((issue) =>
           cloneIssue({
             ...issue,
-            externalId: issue.externalId ?? formatForgejoIssueExternalId(target, issue.number),
+            externalId:
+              issue.externalId ??
+              formatForgejoIssueExternalId({
+                baseUrl: target.baseUrl,
+                owner: target.owner,
+                repo: target.repo,
+                issueNumber: issue.number,
+              }),
             sourceUrl: issue.sourceUrl ?? createForgejoIssueSourceUrl(target, issue.number),
             assignees: [...(issue.assignees ?? [])],
           })
@@ -242,7 +243,12 @@ export function createInMemoryForgejoIssueClient(): InMemoryForgejoIssueClient {
       const timestamp = new Date().toISOString();
       const createdIssue: ForgejoIssue = {
         number: nextIssueNumber,
-        externalId: formatForgejoIssueExternalId(target, nextIssueNumber),
+        externalId: formatForgejoIssueExternalId({
+          baseUrl: target.baseUrl,
+          owner: target.owner,
+          repo: target.repo,
+          issueNumber: nextIssueNumber,
+        }),
         title: input.title,
         body: input.body,
         state: input.state ?? "open",

--- a/src/forgejo-http-client.ts
+++ b/src/forgejo-http-client.ts
@@ -1,7 +1,6 @@
 import type { ForgejoAuthType } from "@/forgejo-config";
 import {
   createForgejoAuthorizationHeader,
-  formatForgejoIssueExternalId,
   type CreateForgejoIssueInput,
   type ForgejoComment,
   type ForgejoHttpClientOptions,
@@ -11,6 +10,7 @@ import {
   type ListForgejoIssuesOptions,
   type UpdateForgejoIssueInput,
 } from "@/forgejo-client";
+import { formatForgejoIssueExternalId } from "@/forgejo-ids";
 
 interface ForgejoApiIssue {
   number: number;
@@ -45,7 +45,12 @@ function normalizeAssignees(assignees?: Array<{ login?: string; username?: strin
 function mapApiIssue(target: ForgejoRepositoryTarget, raw: ForgejoApiIssue): ForgejoIssue {
   return {
     number: raw.number,
-    externalId: formatForgejoIssueExternalId(target, raw.number),
+    externalId: formatForgejoIssueExternalId({
+      baseUrl: target.baseUrl,
+      owner: target.owner,
+      repo: target.repo,
+      issueNumber: raw.number,
+    }),
     title: raw.title,
     body: raw.body ?? undefined,
     state: raw.state,

--- a/src/forgejo-ids.ts
+++ b/src/forgejo-ids.ts
@@ -1,0 +1,96 @@
+import { createTaskId, type Task } from "@todu/core";
+
+export interface ForgejoIssueRef {
+  baseUrl: string;
+  owner: string;
+  repo: string;
+  issueNumber: number;
+}
+
+export class ForgejoExternalIdError extends Error {
+  readonly details?: Record<string, unknown>;
+
+  constructor(message: string, details?: Record<string, unknown>) {
+    super(message);
+    this.name = "ForgejoExternalIdError";
+    this.details = details;
+  }
+}
+
+export function formatForgejoIssueExternalId(issue: ForgejoIssueRef): string {
+  return `${issue.baseUrl}/${issue.owner}/${issue.repo}#${issue.issueNumber}`;
+}
+
+export function parseForgejoIssueExternalId(externalId: string): ForgejoIssueRef {
+  const normalizedExternalId = externalId.trim();
+  if (!normalizedExternalId) {
+    throw new ForgejoExternalIdError("Invalid Forgejo externalId: value is required", {
+      externalId,
+    });
+  }
+
+  const issueDelimiterIndex = normalizedExternalId.lastIndexOf("#");
+  if (issueDelimiterIndex <= 0 || issueDelimiterIndex === normalizedExternalId.length - 1) {
+    throw new ForgejoExternalIdError(
+      `Invalid Forgejo externalId \`${externalId}\`: expected <baseUrl>/<owner>/<repo>#<number> format`,
+      {
+        externalId,
+      }
+    );
+  }
+
+  const baseAndRepo = normalizedExternalId.slice(0, issueDelimiterIndex);
+  const issueNumberText = normalizedExternalId.slice(issueDelimiterIndex + 1);
+  const issueNumber = Number.parseInt(issueNumberText, 10);
+
+  if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
+    throw new ForgejoExternalIdError(
+      `Invalid Forgejo externalId \`${externalId}\`: issue number must be a positive integer`,
+      {
+        externalId,
+        issueNumber: issueNumberText,
+      }
+    );
+  }
+
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(baseAndRepo);
+  } catch {
+    throw new ForgejoExternalIdError(
+      `Invalid Forgejo externalId \`${externalId}\`: expected a valid base URL before /owner/repo`,
+      {
+        externalId,
+      }
+    );
+  }
+
+  const pathSegments = parsedUrl.pathname.split("/").filter(Boolean);
+  if (pathSegments.length < 2) {
+    throw new ForgejoExternalIdError(
+      `Invalid Forgejo externalId \`${externalId}\`: expected <baseUrl>/<owner>/<repo>#<number> format`,
+      {
+        externalId,
+      }
+    );
+  }
+
+  const repo = pathSegments[pathSegments.length - 1];
+  const owner = pathSegments[pathSegments.length - 2];
+  const basePathSegments = pathSegments.slice(0, -2);
+  parsedUrl.pathname = basePathSegments.length > 0 ? `/${basePathSegments.join("/")}` : "/";
+  parsedUrl.search = "";
+  parsedUrl.hash = "";
+  const baseUrl = parsedUrl.toString().replace(/\/$/, "");
+
+  return {
+    baseUrl,
+    owner,
+    repo,
+    issueNumber,
+  };
+}
+
+export function createImportedTaskId(externalId: string): Task["id"] {
+  return createTaskId(`forgejo:${externalId}`);
+}

--- a/src/forgejo-links.ts
+++ b/src/forgejo-links.ts
@@ -1,0 +1,171 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import type { IntegrationBinding, Task } from "@todu/core";
+
+import type { ForgejoIssue } from "@/forgejo-client";
+import { createImportedTaskId } from "@/forgejo-ids";
+import { formatForgejoIssueExternalId } from "@/forgejo-ids";
+
+export interface ForgejoItemLink {
+  bindingId: IntegrationBinding["id"];
+  taskId: Task["id"];
+  issueNumber: number;
+  externalId: string;
+}
+
+export interface ForgejoItemLinkStore {
+  getByTaskId(bindingId: IntegrationBinding["id"], taskId: Task["id"]): ForgejoItemLink | null;
+  getByIssueNumber(
+    bindingId: IntegrationBinding["id"],
+    issueNumber: number
+  ): ForgejoItemLink | null;
+  list(bindingId: IntegrationBinding["id"]): ForgejoItemLink[];
+  listAll(): ForgejoItemLink[];
+  save(link: ForgejoItemLink): void;
+}
+
+export function createInMemoryForgejoItemLinkStore(): ForgejoItemLinkStore {
+  const links = new Map<string, ForgejoItemLink>();
+
+  const getTaskKey = (bindingId: IntegrationBinding["id"], taskId: Task["id"]): string =>
+    `task:${bindingId}:${taskId}`;
+  const getIssueKey = (bindingId: IntegrationBinding["id"], issueNumber: number): string =>
+    `issue:${bindingId}:${issueNumber}`;
+
+  return {
+    getByTaskId(bindingId, taskId): ForgejoItemLink | null {
+      return links.get(getTaskKey(bindingId, taskId)) ?? null;
+    },
+    getByIssueNumber(bindingId, issueNumber): ForgejoItemLink | null {
+      return links.get(getIssueKey(bindingId, issueNumber)) ?? null;
+    },
+    list(bindingId): ForgejoItemLink[] {
+      const bindingLinks = new Map<string, ForgejoItemLink>();
+
+      for (const link of links.values()) {
+        if (link.bindingId === bindingId) {
+          bindingLinks.set(link.externalId, link);
+        }
+      }
+
+      return [...bindingLinks.values()];
+    },
+    listAll(): ForgejoItemLink[] {
+      const allLinks = new Map<string, ForgejoItemLink>();
+
+      for (const link of links.values()) {
+        allLinks.set(link.externalId, link);
+      }
+
+      return [...allLinks.values()];
+    },
+    save(link): void {
+      links.set(getTaskKey(link.bindingId, link.taskId), link);
+      links.set(getIssueKey(link.bindingId, link.issueNumber), link);
+    },
+  };
+}
+
+export function createFileForgejoItemLinkStore(storagePath: string): ForgejoItemLinkStore {
+  const readLinks = (): ForgejoItemLink[] => {
+    if (!fs.existsSync(storagePath)) {
+      return [];
+    }
+
+    const rawContent = fs.readFileSync(storagePath, "utf8");
+    if (!rawContent.trim()) {
+      return [];
+    }
+
+    const parsedContent = JSON.parse(rawContent) as unknown;
+    if (!Array.isArray(parsedContent)) {
+      throw new Error(`Invalid Forgejo item link store at ${storagePath}: expected JSON array`);
+    }
+
+    return parsedContent.map((link) => {
+      if (!link || typeof link !== "object") {
+        throw new Error(`Invalid Forgejo item link store at ${storagePath}: invalid link record`);
+      }
+
+      return link as ForgejoItemLink;
+    });
+  };
+
+  const writeLinks = (links: ForgejoItemLink[]): void => {
+    fs.mkdirSync(path.dirname(storagePath), { recursive: true });
+    fs.writeFileSync(storagePath, `${JSON.stringify(links, null, 2)}\n`, "utf8");
+  };
+
+  const getLink = (predicate: (link: ForgejoItemLink) => boolean): ForgejoItemLink | null =>
+    readLinks().find(predicate) ?? null;
+
+  return {
+    getByTaskId(bindingId, taskId): ForgejoItemLink | null {
+      return getLink((link) => link.bindingId === bindingId && link.taskId === taskId);
+    },
+    getByIssueNumber(bindingId, issueNumber): ForgejoItemLink | null {
+      return getLink((link) => link.bindingId === bindingId && link.issueNumber === issueNumber);
+    },
+    list(bindingId): ForgejoItemLink[] {
+      return readLinks().filter((link) => link.bindingId === bindingId);
+    },
+    listAll(): ForgejoItemLink[] {
+      return readLinks();
+    },
+    save(link): void {
+      const existingLinks = readLinks().filter(
+        (existingLink) =>
+          !(
+            existingLink.bindingId === link.bindingId &&
+            (existingLink.taskId === link.taskId || existingLink.issueNumber === link.issueNumber)
+          )
+      );
+      existingLinks.push(link);
+      writeLinks(existingLinks);
+    },
+  };
+}
+
+export function createLinkFromIssue(input: {
+  binding: IntegrationBinding;
+  issue: ForgejoIssue;
+  baseUrl: string;
+  owner: string;
+  repo: string;
+}): ForgejoItemLink {
+  const externalId = formatForgejoIssueExternalId({
+    baseUrl: input.baseUrl,
+    owner: input.owner,
+    repo: input.repo,
+    issueNumber: input.issue.number,
+  });
+
+  return {
+    bindingId: input.binding.id,
+    taskId: createImportedTaskId(externalId),
+    issueNumber: input.issue.number,
+    externalId,
+  };
+}
+
+export function createLinkFromTask(input: {
+  binding: IntegrationBinding;
+  taskId: Task["id"];
+  baseUrl: string;
+  owner: string;
+  repo: string;
+  issueNumber: number;
+}): ForgejoItemLink {
+  return {
+    bindingId: input.binding.id,
+    taskId: input.taskId,
+    issueNumber: input.issueNumber,
+    externalId: formatForgejoIssueExternalId({
+      baseUrl: input.baseUrl,
+      owner: input.owner,
+      repo: input.repo,
+      issueNumber: input.issueNumber,
+    }),
+  };
+}

--- a/src/forgejo-provider.ts
+++ b/src/forgejo-provider.ts
@@ -1,6 +1,7 @@
+import path from "node:path";
+
 import {
   SYNC_PROVIDER_API_VERSION,
-  createTaskId,
   type ExternalTask,
   type Project,
   type SyncProvider,
@@ -17,10 +18,26 @@ import {
   parseForgejoBinding,
   type ForgejoRepositoryBinding,
 } from "@/forgejo-binding";
-import { type ForgejoIssueClient } from "@/forgejo-client";
-import { createInMemoryForgejoIssueClient, type ForgejoRepositoryTarget } from "@/forgejo-client";
+import {
+  bootstrapForgejoIssuesToTasks,
+  bootstrapTasksToForgejoIssues,
+  type ForgejoBootstrapExportResult,
+  type ForgejoBootstrapImportResult,
+} from "@/forgejo-bootstrap";
+import {
+  createInMemoryForgejoIssueClient,
+  type ForgejoIssueClient,
+  type ForgejoRepositoryTarget,
+} from "@/forgejo-client";
 import { loadForgejoProviderSettings, type ForgejoProviderSettings } from "@/forgejo-config";
 import { createHttpForgejoIssueClient } from "@/forgejo-http-client";
+import {
+  createFileForgejoItemLinkStore,
+  createInMemoryForgejoItemLinkStore,
+  type ForgejoItemLink,
+  type ForgejoItemLinkStore,
+} from "@/forgejo-links";
+import { createImportedTaskId } from "@/forgejo-ids";
 
 export const FORGEJO_PROVIDER_VERSION = "0.1.0";
 
@@ -31,6 +48,9 @@ const OPEN_STATUSES = new Set<Task["status"]>(["active", "inprogress", "waiting"
 export interface ForgejoProviderState {
   initialized: boolean;
   settings: ForgejoProviderSettings | null;
+  itemLinks: ForgejoItemLink[];
+  lastPullResult: ForgejoBootstrapImportResult | null;
+  lastPushResult: ForgejoBootstrapExportResult | null;
 }
 
 export interface ForgejoSyncProvider extends SyncProvider {
@@ -39,11 +59,8 @@ export interface ForgejoSyncProvider extends SyncProvider {
 
 export interface CreateForgejoSyncProviderOptions {
   issueClient?: ForgejoIssueClient;
+  linkStore?: ForgejoItemLinkStore;
   initialConfig?: SyncProviderConfig | null;
-}
-
-export function createImportedTaskId(externalId: string): Task["id"] {
-  return createTaskId(`forgejo:${externalId}`);
 }
 
 export function createForgejoRepositoryTarget(
@@ -62,7 +79,10 @@ export function createForgejoSyncProvider(
   options: CreateForgejoSyncProviderOptions = {}
 ): ForgejoSyncProvider {
   let settings = options.initialConfig ? loadForgejoProviderSettings(options.initialConfig) : null;
+  let lastPullResult: ForgejoBootstrapImportResult | null = null;
+  let lastPushResult: ForgejoBootstrapExportResult | null = null;
   let issueClient: ForgejoIssueClient = options.issueClient ?? createInMemoryForgejoIssueClient();
+  let linkStore = options.linkStore ?? createInMemoryForgejoItemLinkStore();
 
   const requireInitializedSettings = (): ForgejoProviderSettings => {
     if (!settings) {
@@ -91,24 +111,82 @@ export function createForgejoSyncProvider(
           authType: settings.authType,
         });
       }
+      if (!options.linkStore) {
+        linkStore = createFileForgejoItemLinkStore(
+          path.join(settings.storageDir, "item-links.json")
+        );
+      }
     },
     async shutdown(): Promise<void> {
       settings = null;
+      lastPullResult = null;
+      lastPushResult = null;
       if (!options.issueClient) {
         issueClient = createInMemoryForgejoIssueClient();
+      }
+      if (!options.linkStore) {
+        linkStore = createInMemoryForgejoItemLinkStore();
       }
     },
     async pull(binding, _project): Promise<SyncProviderPullResult> {
       const parsedBinding = validateBinding(binding);
-      void createForgejoRepositoryTarget(parsedBinding, requireInitializedSettings());
-      void issueClient;
-      return { tasks: [] };
+      const currentSettings = requireInitializedSettings();
+      const target = createForgejoRepositoryTarget(parsedBinding, currentSettings);
+
+      if (binding.strategy === "none" || binding.strategy === "push") {
+        lastPullResult = { tasks: [], createdLinks: [] };
+        return { tasks: [] };
+      }
+
+      lastPullResult = await bootstrapForgejoIssuesToTasks({
+        binding,
+        baseUrl: target.baseUrl,
+        apiBaseUrl: target.apiBaseUrl,
+        owner: target.owner,
+        repo: target.repo,
+        issueClient,
+        linkStore,
+      });
+
+      return { tasks: lastPullResult.tasks };
     },
-    async push(binding, _tasks, _project): Promise<SyncProviderPushResult> {
+    async push(binding, tasks, _project): Promise<SyncProviderPushResult> {
       const parsedBinding = validateBinding(binding);
-      void createForgejoRepositoryTarget(parsedBinding, requireInitializedSettings());
-      void issueClient;
-      return { commentLinks: [], taskLinks: [] };
+      const currentSettings = requireInitializedSettings();
+      const target = createForgejoRepositoryTarget(parsedBinding, currentSettings);
+
+      if (binding.strategy === "none" || binding.strategy === "pull") {
+        lastPushResult = {
+          createdIssues: [],
+          updatedIssues: [],
+          createdLinks: [],
+          taskUpdates: [],
+        };
+        return { commentLinks: [], taskLinks: [] };
+      }
+
+      lastPushResult = await bootstrapTasksToForgejoIssues({
+        binding,
+        baseUrl: target.baseUrl,
+        apiBaseUrl: target.apiBaseUrl,
+        owner: target.owner,
+        repo: target.repo,
+        tasks,
+        issueClient,
+        linkStore,
+      });
+
+      const pushResult = lastPushResult;
+
+      return {
+        commentLinks: [],
+        taskLinks: pushResult.createdLinks.map((link) => ({
+          localTaskId: link.taskId,
+          externalId: link.externalId,
+          sourceUrl: pushResult.taskUpdates.find((update) => update.taskId === link.taskId)
+            ?.sourceUrl,
+        })),
+      };
     },
     mapToTask(external: ExternalTask, project: Project): Task {
       return {
@@ -143,6 +221,9 @@ export function createForgejoSyncProvider(
       return {
         initialized: settings !== null,
         settings,
+        itemLinks: linkStore.listAll(),
+        lastPullResult,
+        lastPushResult,
       };
     },
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,6 @@ export {
   createForgejoCommentSourceUrl,
   createForgejoIssueSourceUrl,
   createInMemoryForgejoIssueClient,
-  formatForgejoIssueExternalId,
   type CreateForgejoIssueInput,
   type ForgejoComment,
   type ForgejoHttpClientOptions,
@@ -31,12 +30,27 @@ export {
   type ListForgejoIssuesOptions,
   type UpdateForgejoIssueInput,
 } from "@/forgejo-client";
+export { bootstrapForgejoIssuesToTasks, bootstrapTasksToForgejoIssues } from "@/forgejo-bootstrap";
 export { createHttpForgejoIssueClient } from "@/forgejo-http-client";
+export {
+  createFileForgejoItemLinkStore,
+  createInMemoryForgejoItemLinkStore,
+  createLinkFromIssue,
+  createLinkFromTask,
+  type ForgejoItemLink,
+  type ForgejoItemLinkStore,
+} from "@/forgejo-links";
+export {
+  ForgejoExternalIdError,
+  createImportedTaskId,
+  formatForgejoIssueExternalId,
+  parseForgejoIssueExternalId,
+  type ForgejoIssueRef,
+} from "@/forgejo-ids";
 export {
   FORGEJO_PROVIDER_VERSION,
   createForgejoRepositoryTarget,
   createForgejoSyncProvider,
-  createImportedTaskId,
   forgejoProvider,
   syncProvider,
   type CreateForgejoSyncProviderOptions,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "outDir": "./dist",
     "rootDir": "./src",
     "declaration": true,
-    "types": ["vitest/globals"],
+    "types": ["node", "vitest/globals"],
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]


### PR DESCRIPTION
## Summary
- add Forgejo bootstrap import/export flows for initial issue/task synchronization
- add durable Forgejo item linking plus Forgejo external ID parsing/formatting helpers
- wire bootstrap/linking into the provider and add focused tests for import, export, and existing external ID reuse

## Testing
- npm run format
- npm run lint
- npm run typecheck
- npm test
- npm run build
- make dev
- make dev-stop

Refs task-36f59057