### PR TITLE
feat: add forgejo field sync primitives

### DIFF
--- a/src/forgejo-bootstrap.test.ts
+++ b/src/forgejo-bootstrap.test.ts
@@ -31,7 +31,7 @@ const target = {
 };
 
 describe("forgejo bootstrap", () => {
-  it("imports open issues and creates durable links", async () => {
+  it("imports open issues with normalized fields and creates durable links", async () => {
     const issueClient = createInMemoryForgejoIssueClient();
     const linkStore = createInMemoryForgejoItemLinkStore();
 
@@ -42,7 +42,7 @@ describe("forgejo bootstrap", () => {
         title: "Open issue",
         body: "Imported body",
         state: "open",
-        labels: ["bug"],
+        labels: ["bug", "status:inprogress", "priority:high"],
         assignees: ["erik"],
         createdAt: "2026-03-12T00:00:00.000Z",
         updatedAt: "2026-03-12T00:00:00.000Z",
@@ -73,13 +73,17 @@ describe("forgejo bootstrap", () => {
     expect(result.tasks[0].externalId).toBe(
       "https://forgejo.caradoc.com/erik/todu-forgejo-plugin-test#1"
     );
+    expect(result.tasks[0].status).toBe("inprogress");
+    expect(result.tasks[0].priority).toBe("high");
+    expect(result.tasks[0].labels).toEqual(["bug"]);
+    expect(result.tasks[0].assignees).toEqual(["erik"]);
     expect(result.createdLinks).toHaveLength(1);
     expect(linkStore.getByIssueNumber(binding.id, 1)?.externalId).toBe(
       "https://forgejo.caradoc.com/erik/todu-forgejo-plugin-test#1"
     );
   });
 
-  it("exports active tasks to forgejo and assigns external ids and source urls", async () => {
+  it("exports active tasks to forgejo with normalized fields and creates missing labels", async () => {
     const issueClient = createInMemoryForgejoIssueClient();
     const linkStore = createInMemoryForgejoItemLinkStore();
     const tasks: TaskPushPayload[] = [
@@ -90,7 +94,7 @@ describe("forgejo bootstrap", () => {
         status: "active",
         priority: "high",
         projectId: binding.projectId,
-        labels: [],
+        labels: ["bug"],
         assignees: [],
         comments: [],
         createdAt: "2026-03-12T00:00:00.000Z",
@@ -122,6 +126,9 @@ describe("forgejo bootstrap", () => {
     });
 
     expect(result.createdIssues).toHaveLength(1);
+    expect(result.createdIssues[0].state).toBe("open");
+    expect(result.createdIssues[0].labels).toEqual(["bug", "status:active", "priority:high"]);
+    expect(issueClient.snapshotLabels(target)).toContain("bug");
     expect(result.createdLinks).toHaveLength(1);
     expect(tasks[0].externalId).toBeDefined();
     expect(tasks[0].sourceUrl).toBe(
@@ -155,7 +162,7 @@ describe("forgejo bootstrap", () => {
         status: "active",
         priority: "medium",
         projectId: binding.projectId,
-        labels: [],
+        labels: ["needs-review"],
         assignees: [],
         comments: [],
         createdAt: "2026-03-12T00:00:00.000Z",
@@ -177,6 +184,12 @@ describe("forgejo bootstrap", () => {
     expect(result.createdIssues).toHaveLength(0);
     expect(result.createdLinks).toHaveLength(1);
     expect(result.updatedIssues).toHaveLength(1);
+    expect(result.updatedIssues[0].labels).toEqual([
+      "needs-review",
+      "status:active",
+      "priority:medium",
+    ]);
+    expect(issueClient.snapshotLabels(target)).toContain("needs-review");
     expect(linkStore.getByTaskId(binding.id, tasks[0].id)?.issueNumber).toBe(7);
     expect(parseForgejoIssueExternalId(tasks[0].externalId!).issueNumber).toBe(7);
   });

--- a/src/forgejo-bootstrap.ts
+++ b/src/forgejo-bootstrap.ts
@@ -5,6 +5,12 @@ import {
   type ForgejoIssue,
   type ForgejoIssueClient,
 } from "@/forgejo-client";
+import {
+  createForgejoIssueCreateFromTask,
+  createForgejoIssueUpdateFromTask,
+  mapForgejoIssueToExternalTask,
+} from "@/forgejo-fields";
+import { getNormalForgejoLabels } from "@/forgejo-fields";
 import { parseForgejoIssueExternalId } from "@/forgejo-ids";
 import {
   createLinkFromIssue,
@@ -82,19 +88,7 @@ export async function bootstrapForgejoIssuesToTasks(input: {
       createdLinks.push(createdLink);
     }
 
-    tasks.push({
-      externalId: issue.externalId,
-      priority: "medium",
-      title: issue.title,
-      description: issue.body,
-      status: issue.state === "closed" ? "done" : "active",
-      labels: [...issue.labels],
-      assignees: [...issue.assignees],
-      sourceUrl: issue.sourceUrl,
-      createdAt: issue.createdAt,
-      updatedAt: issue.updatedAt,
-      raw: issue,
-    });
+    tasks.push(mapForgejoIssueToExternalTask(issue));
   }
 
   return {
@@ -125,6 +119,18 @@ export async function bootstrapTasksToForgejoIssues(input: {
     repo: input.repo,
   };
 
+  const ensureLabelsExist = async (labels: string[]): Promise<void> => {
+    const normalLabels = getNormalForgejoLabels(labels);
+    const existingLabels = new Set(await input.issueClient.listLabels(target));
+
+    for (const label of normalLabels) {
+      if (!existingLabels.has(label)) {
+        await input.issueClient.createLabel(target, label);
+        existingLabels.add(label);
+      }
+    }
+  };
+
   for (const task of input.tasks) {
     const existingLink = input.linkStore.getByTaskId(input.binding.id, task.id);
     if (existingLink) {
@@ -133,10 +139,13 @@ export async function bootstrapTasksToForgejoIssues(input: {
       task.sourceUrl = existingIssue?.sourceUrl ?? task.sourceUrl;
 
       if (shouldPushTaskUpdate(task, existingIssue)) {
-        const updatedIssue = await input.issueClient.updateIssue(target, existingLink.issueNumber, {
-          title: task.title,
-          body: task.description,
-        });
+        const issueUpdate = createForgejoIssueUpdateFromTask(task);
+        await ensureLabelsExist(issueUpdate.labels ?? []);
+        const updatedIssue = await input.issueClient.updateIssue(
+          target,
+          existingLink.issueNumber,
+          issueUpdate
+        );
         task.sourceUrl = updatedIssue.sourceUrl;
         updatedIssues.push(updatedIssue);
       }
@@ -163,13 +172,12 @@ export async function bootstrapTasksToForgejoIssues(input: {
         matchingExternalId.issueNumber
       );
       if (shouldPushTaskUpdate(task, existingIssue)) {
+        const issueUpdate = createForgejoIssueUpdateFromTask(task);
+        await ensureLabelsExist(issueUpdate.labels ?? []);
         const updatedIssue = await input.issueClient.updateIssue(
           target,
           matchingExternalId.issueNumber,
-          {
-            title: task.title,
-            body: task.description,
-          }
+          issueUpdate
         );
         task.sourceUrl = updatedIssue.sourceUrl;
         updatedIssues.push(updatedIssue);
@@ -181,11 +189,9 @@ export async function bootstrapTasksToForgejoIssues(input: {
       continue;
     }
 
-    const createdIssue = await input.issueClient.createIssue(target, {
-      title: task.title,
-      body: task.description,
-      state: "open",
-    });
+    const issueCreate = createForgejoIssueCreateFromTask(task);
+    await ensureLabelsExist(issueCreate.labels ?? []);
+    const createdIssue = await input.issueClient.createIssue(target, issueCreate);
 
     createdIssues.push(createdIssue);
 

--- a/src/forgejo-client.ts
+++ b/src/forgejo-client.ts
@@ -64,6 +64,8 @@ export interface ForgejoIssueClient {
     issueNumber: number,
     input: UpdateForgejoIssueInput
   ): Promise<ForgejoIssue>;
+  listLabels(target: ForgejoRepositoryTarget): Promise<string[]>;
+  createLabel(target: ForgejoRepositoryTarget, name: string): Promise<void>;
   listComments(target: ForgejoRepositoryTarget, issueNumber: number): Promise<ForgejoComment[]>;
   createComment(
     target: ForgejoRepositoryTarget,
@@ -87,6 +89,7 @@ export interface InMemoryForgejoIssueClient extends ForgejoIssueClient {
   ): void;
   snapshotIssues(target: ForgejoRepositoryTarget): ForgejoIssue[];
   snapshotComments(target: ForgejoRepositoryTarget, issueNumber: number): ForgejoComment[];
+  snapshotLabels(target: ForgejoRepositoryTarget): string[];
 }
 
 export interface ForgejoHttpClientOptions {
@@ -118,6 +121,7 @@ export function createForgejoAuthorizationHeader(
 
 export function createInMemoryForgejoIssueClient(): InMemoryForgejoIssueClient {
   const issuesByRepository = new Map<string, ForgejoIssue[]>();
+  const labelsByRepository = new Map<string, Set<string>>();
   const commentsByIssue = new Map<string, ForgejoComment[]>();
   let nextCommentId = 1;
 
@@ -134,6 +138,18 @@ export function createInMemoryForgejoIssueClient(): InMemoryForgejoIssueClient {
 
   const setIssues = (target: ForgejoRepositoryTarget, issues: ForgejoIssue[]): void => {
     issuesByRepository.set(getRepositoryKey(target), issues);
+  };
+
+  const getLabels = (target: ForgejoRepositoryTarget): Set<string> => {
+    const repositoryKey = getRepositoryKey(target);
+    const existingLabels = labelsByRepository.get(repositoryKey);
+    if (existingLabels) {
+      return existingLabels;
+    }
+
+    const labels = new Set<string>();
+    labelsByRepository.set(repositoryKey, labels);
+    return labels;
   };
 
   const getComments = (target: ForgejoRepositoryTarget, issueNumber: number): ForgejoComment[] =>
@@ -176,10 +192,15 @@ export function createInMemoryForgejoIssueClient(): InMemoryForgejoIssueClient {
 
   return {
     seedIssues(target, issues): void {
+      const labels = getLabels(target);
       setIssues(
         target,
-        issues.map((issue) =>
-          cloneIssue({
+        issues.map((issue) => {
+          for (const label of issue.labels ?? []) {
+            labels.add(label);
+          }
+
+          return cloneIssue({
             ...issue,
             externalId:
               issue.externalId ??
@@ -191,8 +212,8 @@ export function createInMemoryForgejoIssueClient(): InMemoryForgejoIssueClient {
               }),
             sourceUrl: issue.sourceUrl ?? createForgejoIssueSourceUrl(target, issue.number),
             assignees: [...(issue.assignees ?? [])],
-          })
-        )
+          });
+        })
       );
     },
     seedComments(target, issueNumber, comments): void {
@@ -218,6 +239,9 @@ export function createInMemoryForgejoIssueClient(): InMemoryForgejoIssueClient {
     snapshotComments(target, issueNumber): ForgejoComment[] {
       return getComments(target, issueNumber).map(cloneComment);
     },
+    snapshotLabels(target): string[] {
+      return [...getLabels(target)].sort();
+    },
     async listIssues(target, options): Promise<ForgejoIssue[]> {
       return getIssues(target)
         .filter((issue) => !issue.isPullRequest)
@@ -239,6 +263,11 @@ export function createInMemoryForgejoIssueClient(): InMemoryForgejoIssueClient {
     },
     async createIssue(target, input): Promise<ForgejoIssue> {
       const issues = getIssues(target);
+      const labels = [...(input.labels ?? [])];
+      for (const label of labels) {
+        getLabels(target).add(label);
+      }
+
       const nextIssueNumber = issues.reduce((max, issue) => Math.max(max, issue.number), 0) + 1;
       const timestamp = new Date().toISOString();
       const createdIssue: ForgejoIssue = {
@@ -252,7 +281,7 @@ export function createInMemoryForgejoIssueClient(): InMemoryForgejoIssueClient {
         title: input.title,
         body: input.body,
         state: input.state ?? "open",
-        labels: [...(input.labels ?? [])],
+        labels,
         assignees: [],
         sourceUrl: createForgejoIssueSourceUrl(target, nextIssueNumber),
         createdAt: timestamp,
@@ -270,12 +299,17 @@ export function createInMemoryForgejoIssueClient(): InMemoryForgejoIssueClient {
       }
 
       const existingIssue = issues[index];
+      const labels = input.labels ? [...input.labels] : [...existingIssue.labels];
+      for (const label of labels) {
+        getLabels(target).add(label);
+      }
+
       const updatedIssue: ForgejoIssue = {
         ...existingIssue,
         title: input.title ?? existingIssue.title,
         body: input.body ?? existingIssue.body,
         state: input.state ?? existingIssue.state,
-        labels: input.labels ? [...input.labels] : [...existingIssue.labels],
+        labels,
         updatedAt: new Date().toISOString(),
       };
 
@@ -283,6 +317,12 @@ export function createInMemoryForgejoIssueClient(): InMemoryForgejoIssueClient {
       nextIssues[index] = updatedIssue;
       setIssues(target, nextIssues);
       return cloneIssue(updatedIssue);
+    },
+    async listLabels(target): Promise<string[]> {
+      return [...getLabels(target)].sort();
+    },
+    async createLabel(target, name): Promise<void> {
+      getLabels(target).add(name);
     },
     async listComments(target, issueNumber): Promise<ForgejoComment[]> {
       return getComments(target, issueNumber).map(cloneComment);

--- a/src/forgejo-fields.test.ts
+++ b/src/forgejo-fields.test.ts
@@ -1,0 +1,57 @@
+import {
+  createForgejoIssueCreateFromTask,
+  getNormalForgejoLabels,
+  normalizeForgejoIssuePriority,
+  normalizeForgejoIssueStatus,
+} from "@/forgejo-fields";
+
+describe("forgejo fields", () => {
+  it("maps task fields into forgejo issue payloads", () => {
+    const payload = createForgejoIssueCreateFromTask({
+      id: "task-1" as never,
+      title: "Ship feature",
+      description: "Markdown body",
+      status: "inprogress",
+      priority: "high",
+      projectId: "project-1" as never,
+      labels: ["bug", "priority:low"],
+      assignees: [],
+      createdAt: "2026-03-12T00:00:00.000Z",
+      updatedAt: "2026-03-12T00:00:00.000Z",
+    });
+
+    expect(payload).toEqual({
+      title: "Ship feature",
+      body: "Markdown body",
+      state: "open",
+      labels: ["bug", "status:inprogress", "priority:high"],
+    });
+  });
+
+  it("normalizes forgejo issue status deterministically", () => {
+    expect(normalizeForgejoIssueStatus("open", ["status:waiting", "status:active"])).toEqual({
+      state: "open",
+      status: "active",
+      statusLabel: "status:active",
+    });
+
+    expect(normalizeForgejoIssueStatus("closed", ["status:canceled"])).toEqual({
+      state: "closed",
+      status: "canceled",
+      statusLabel: "status:canceled",
+    });
+  });
+
+  it("normalizes forgejo issue priority deterministically", () => {
+    expect(normalizeForgejoIssuePriority(["priority:low", "priority:high"])).toEqual({
+      priority: "high",
+      priorityLabel: "priority:high",
+    });
+  });
+
+  it("filters reserved labels from normal labels", () => {
+    expect(
+      getNormalForgejoLabels(["bug", "status:active", "priority:medium", "needs-review"])
+    ).toEqual(["bug", "needs-review"]);
+  });
+});

--- a/src/forgejo-fields.ts
+++ b/src/forgejo-fields.ts
@@ -1,0 +1,189 @@
+import type { ExternalTask, Task, TaskStatus, TaskWithDetail } from "@todu/core";
+
+import type {
+  CreateForgejoIssueInput,
+  ForgejoIssue,
+  UpdateForgejoIssueInput,
+} from "@/forgejo-client";
+
+const OPEN_STATUS_PRECEDENCE: TaskStatus[] = ["active", "inprogress", "waiting"];
+const CLOSED_STATUS_PRECEDENCE: TaskStatus[] = ["done", "canceled"];
+const PRIORITY_PRECEDENCE: Task["priority"][] = ["high", "medium", "low"];
+
+export const STATUS_LABEL_PREFIX = "status:";
+export const PRIORITY_LABEL_PREFIX = "priority:";
+
+export interface NormalizedForgejoStatus {
+  status: TaskStatus;
+  state: ForgejoIssue["state"];
+  statusLabel: string;
+}
+
+export interface NormalizedForgejoPriority {
+  priority: Task["priority"];
+  priorityLabel: string;
+}
+
+export interface ForgejoFieldMapping {
+  title: string;
+  description?: string;
+  status: TaskStatus;
+  priority: Task["priority"];
+  labels: string[];
+  assignees: string[];
+}
+
+export function mapForgejoIssueToExternalTask(issue: ForgejoIssue): ExternalTask {
+  const normalizedStatus = normalizeForgejoIssueStatus(issue.state, issue.labels);
+  const normalizedPriority = normalizeForgejoIssuePriority(issue.labels);
+
+  return {
+    externalId: issue.externalId,
+    title: issue.title,
+    description: issue.body,
+    status: normalizedStatus.status,
+    priority: normalizedPriority.priority,
+    labels: getNormalForgejoLabels(issue.labels),
+    assignees: [...issue.assignees],
+    sourceUrl: issue.sourceUrl,
+    createdAt: issue.createdAt,
+    updatedAt: issue.updatedAt,
+    raw: issue,
+  };
+}
+
+export function createForgejoIssueCreateFromTask(task: TaskWithDetail): CreateForgejoIssueInput {
+  const normalizedStatus = createForgejoStatusFromTask(task.status);
+  const normalizedPriority = createForgejoPriorityFromTask(task.priority);
+
+  return {
+    title: task.title,
+    body: task.description,
+    state: normalizedStatus.state,
+    labels: mergeForgejoLabels(
+      task.labels,
+      normalizedStatus.statusLabel,
+      normalizedPriority.priorityLabel
+    ),
+  };
+}
+
+export function createForgejoIssueUpdateFromTask(task: TaskWithDetail): UpdateForgejoIssueInput {
+  return createForgejoIssueCreateFromTask(task);
+}
+
+export function normalizeForgejoIssueStatus(
+  state: ForgejoIssue["state"],
+  labels: string[]
+): NormalizedForgejoStatus {
+  const statusLabels = labels.filter((label) => label.startsWith(STATUS_LABEL_PREFIX));
+
+  if (state === "closed") {
+    const closedStatusLabel = pickPreferredStatusLabel(statusLabels, CLOSED_STATUS_PRECEDENCE);
+    const closedStatus = closedStatusLabel ? parseTaskStatusFromLabel(closedStatusLabel) : "done";
+
+    return {
+      state,
+      status: closedStatus === "canceled" ? "canceled" : "done",
+      statusLabel: createStatusLabel(closedStatus === "canceled" ? "canceled" : "done"),
+    };
+  }
+
+  const openStatusLabel = pickPreferredStatusLabel(statusLabels, OPEN_STATUS_PRECEDENCE);
+  const openStatus = openStatusLabel ? parseTaskStatusFromLabel(openStatusLabel) : "active";
+
+  return {
+    state,
+    status:
+      openStatus === "active" || openStatus === "inprogress" || openStatus === "waiting"
+        ? openStatus
+        : "active",
+    statusLabel: createStatusLabel(
+      openStatus === "active" || openStatus === "inprogress" || openStatus === "waiting"
+        ? openStatus
+        : "active"
+    ),
+  };
+}
+
+export function normalizeForgejoIssuePriority(labels: string[]): NormalizedForgejoPriority {
+  const priorityLabels = labels.filter((label) => label.startsWith(PRIORITY_LABEL_PREFIX));
+  const matchedPriorityLabel = PRIORITY_PRECEDENCE.map(createPriorityLabel).find((label) =>
+    priorityLabels.includes(label)
+  );
+  const priority = matchedPriorityLabel
+    ? parseTaskPriorityFromLabel(matchedPriorityLabel)
+    : "medium";
+
+  return {
+    priority,
+    priorityLabel: createPriorityLabel(priority),
+  };
+}
+
+export function getNormalForgejoLabels(labels: string[]): string[] {
+  return labels.filter(
+    (label) => !label.startsWith(STATUS_LABEL_PREFIX) && !label.startsWith(PRIORITY_LABEL_PREFIX)
+  );
+}
+
+export function mergeForgejoLabels(
+  normalLabels: string[],
+  statusLabel: string,
+  priorityLabel: string
+): string[] {
+  const dedupedNormalLabels = [...new Set(getNormalForgejoLabels(normalLabels))];
+  return [...dedupedNormalLabels, statusLabel, priorityLabel];
+}
+
+export function createForgejoStatusFromTask(status: TaskStatus): NormalizedForgejoStatus {
+  if (status === "done" || status === "canceled") {
+    return {
+      state: "closed",
+      status,
+      statusLabel: createStatusLabel(status),
+    };
+  }
+
+  return {
+    state: "open",
+    status,
+    statusLabel: createStatusLabel(status),
+  };
+}
+
+export function createForgejoPriorityFromTask(
+  priority: Task["priority"]
+): NormalizedForgejoPriority {
+  return {
+    priority,
+    priorityLabel: createPriorityLabel(priority),
+  };
+}
+
+function createStatusLabel(status: TaskStatus): string {
+  return `${STATUS_LABEL_PREFIX}${status}`;
+}
+
+function createPriorityLabel(priority: Task["priority"]): string {
+  return `${PRIORITY_LABEL_PREFIX}${priority}`;
+}
+
+function pickPreferredStatusLabel(labels: string[], precedence: TaskStatus[]): string | null {
+  for (const status of precedence) {
+    const candidate = createStatusLabel(status);
+    if (labels.includes(candidate)) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+function parseTaskStatusFromLabel(label: string): TaskStatus {
+  return label.slice(STATUS_LABEL_PREFIX.length) as TaskStatus;
+}
+
+function parseTaskPriorityFromLabel(label: string): Task["priority"] {
+  return label.slice(PRIORITY_LABEL_PREFIX.length) as Task["priority"];
+}

--- a/src/forgejo-http-client.ts
+++ b/src/forgejo-http-client.ts
@@ -25,6 +25,10 @@ interface ForgejoApiIssue {
   pull_request?: unknown;
 }
 
+interface ForgejoApiLabel {
+  name: string;
+}
+
 interface ForgejoApiComment {
   id: number;
   body: string;
@@ -210,6 +214,26 @@ export function createHttpForgejoIssueClient(
       );
 
       return mapApiIssue(target, rawIssue);
+    },
+
+    async listLabels(target: ForgejoRepositoryTarget): Promise<string[]> {
+      const rawLabels = await listAllPages<ForgejoApiLabel>(
+        target,
+        `/repos/${target.owner}/${target.repo}/labels`
+      );
+      return rawLabels.map((label) => label.name);
+    },
+
+    async createLabel(target: ForgejoRepositoryTarget, name: string): Promise<void> {
+      await request<ForgejoApiLabel>(
+        target,
+        "POST",
+        `/repos/${target.owner}/${target.repo}/labels`,
+        {
+          name,
+          color: "ededed",
+        }
+      );
     },
 
     async listComments(

--- a/src/forgejo-provider.test.ts
+++ b/src/forgejo-provider.test.ts
@@ -2,6 +2,7 @@ import { createIntegrationBindingId, createProjectId, type IntegrationBinding } 
 
 import { FORGEJO_PROVIDER_NAME, FORGEJO_REPOSITORY_TARGET_KIND } from "@/forgejo-binding";
 import { createInMemoryForgejoIssueClient } from "@/forgejo-client";
+import { createInMemoryForgejoItemLinkStore } from "@/forgejo-links";
 import { createForgejoSyncProvider } from "@/forgejo-provider";
 
 function createBinding(overrides: Partial<IntegrationBinding> = {}): IntegrationBinding {
@@ -63,6 +64,28 @@ describe("forgejo provider", () => {
       taskLinks: [],
     });
     await expect(provider.pull(createBinding({ provider: "github" }), project)).rejects.toThrow();
+  });
+
+  it("respects binding strategies for non-comment field sync", async () => {
+    const issueClient = createInMemoryForgejoIssueClient();
+    const provider = createForgejoSyncProvider({
+      issueClient,
+      linkStore: createInMemoryForgejoItemLinkStore(),
+    });
+    await provider.initialize({
+      settings: {
+        baseUrl: "https://code.example.com",
+        token: "secret-token",
+      },
+    });
+
+    await expect(provider.pull(createBinding({ strategy: "push" }), project)).resolves.toEqual({
+      tasks: [],
+    });
+    await expect(provider.push(createBinding({ strategy: "pull" }), [], project)).resolves.toEqual({
+      commentLinks: [],
+      taskLinks: [],
+    });
   });
 
   it("maps external tasks into local tasks with normalized defaults", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,20 @@ export {
   type UpdateForgejoIssueInput,
 } from "@/forgejo-client";
 export { bootstrapForgejoIssuesToTasks, bootstrapTasksToForgejoIssues } from "@/forgejo-bootstrap";
+export {
+  createForgejoIssueCreateFromTask,
+  createForgejoIssueUpdateFromTask,
+  createForgejoPriorityFromTask,
+  createForgejoStatusFromTask,
+  getNormalForgejoLabels,
+  mapForgejoIssueToExternalTask,
+  mergeForgejoLabels,
+  normalizeForgejoIssuePriority,
+  normalizeForgejoIssueStatus,
+  type ForgejoFieldMapping,
+  type NormalizedForgejoPriority,
+  type NormalizedForgejoStatus,
+} from "@/forgejo-fields";
 export { createHttpForgejoIssueClient } from "@/forgejo-http-client";
 export {
   createFileForgejoItemLinkStore,


### PR DESCRIPTION
## Summary
- add Forgejo field normalization helpers for status, priority, labels, and external task mapping
- update bootstrap and client flows to create missing labels and preserve normalized field sync behavior
- extend tests for field mapping, bootstrap behavior, and strategy-aware provider handling

## Verification
- ./scripts/pre-pr.sh
- npm run build
- make dev
- make dev-stop

Task: #task-98ce6f79