### PR TITLE
feat: import closed issues on initial bootstrap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "todu-forgejo-plugin",
       "version": "0.1.0",
       "dependencies": {
-        "@todu/core": "^0.7.3"
+        "@todu/core": "^0.9.0"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -1073,9 +1073,9 @@
       "license": "MIT"
     },
     "node_modules/@todu/core": {
-      "version": "0.7.7",
-      "resolved": "https://registry.npmjs.org/@todu/core/-/core-0.7.7.tgz",
-      "integrity": "sha512-mHNO8O1HUFv7Om2y7ThEeXav0/sSddBBz35GvxTyJD1sXD+96xbDhjZsnbZdIstntcSCFf0Rgj+C5yekdyMs6w==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@todu/core/-/core-0.9.0.tgz",
+      "integrity": "sha512-SZUg1MwNn5TCVveTssXy0NLEVUKqXH7VSD07y2I+dFZgCKALWklHeHnN3BMK6itUsWwBiDCYb7NkshmCCmdqvg==",
       "license": "MIT",
       "engines": {
         "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
     "vitest": "^4.0.18"
   },
   "dependencies": {
-    "@todu/core": "^0.7.3"
+    "@todu/core": "^0.9.0"
   }
 }

--- a/src/forgejo-bootstrap-hardening.test.ts
+++ b/src/forgejo-bootstrap-hardening.test.ts
@@ -242,6 +242,99 @@ describe("bootstrap status transitions", () => {
     expect(result.tasks[0].status).toBe("canceled");
   });
 
+  it("skips unlinked closed issues during initial bootstrap by default", async () => {
+    const issueClient = createInMemoryForgejoIssueClient();
+    const linkStore = createInMemoryForgejoItemLinkStore();
+
+    issueClient.seedIssues(target, [
+      {
+        number: 1,
+        externalId: "https://code.example.com/acme/roadmap#1",
+        title: "Closed issue",
+        state: "closed",
+        labels: ["status:done"],
+        assignees: [],
+        createdAt: "2026-03-12T00:00:00.000Z",
+        updatedAt: "2026-03-12T01:00:00.000Z",
+      },
+    ]);
+
+    const result = await bootstrapForgejoIssuesToTasks({
+      binding,
+      ...target,
+      issueClient,
+      linkStore,
+    });
+
+    expect(result.tasks).toHaveLength(0);
+    expect(result.createdLinks).toHaveLength(0);
+  });
+
+  it("imports unlinked closed issues during initial bootstrap when opt-in is enabled", async () => {
+    const issueClient = createInMemoryForgejoIssueClient();
+    const linkStore = createInMemoryForgejoItemLinkStore();
+
+    issueClient.seedIssues(target, [
+      {
+        number: 1,
+        externalId: "https://code.example.com/acme/roadmap#1",
+        title: "Canceled issue",
+        state: "closed",
+        labels: ["status:canceled", "priority:high"],
+        assignees: [],
+        createdAt: "2026-03-12T00:00:00.000Z",
+        updatedAt: "2026-03-12T01:00:00.000Z",
+      },
+    ]);
+
+    const result = await bootstrapForgejoIssuesToTasks({
+      binding,
+      ...target,
+      issueClient,
+      linkStore,
+      importClosedOnBootstrap: true,
+    });
+
+    expect(result.tasks).toHaveLength(1);
+    expect(result.tasks[0]).toMatchObject({
+      title: "Canceled issue",
+      status: "canceled",
+      priority: "high",
+    });
+    expect(result.createdLinks).toHaveLength(1);
+    expect(linkStore.getByIssueNumber(binding.id, 1)).not.toBeNull();
+  });
+
+  it("does not import newly seen closed issues during incremental pull even when opt-in is enabled", async () => {
+    const issueClient = createInMemoryForgejoIssueClient();
+    const linkStore = createInMemoryForgejoItemLinkStore();
+
+    issueClient.seedIssues(target, [
+      {
+        number: 1,
+        externalId: "https://code.example.com/acme/roadmap#1",
+        title: "Closed issue",
+        state: "closed",
+        labels: ["status:done"],
+        assignees: [],
+        createdAt: "2026-03-12T00:00:00.000Z",
+        updatedAt: "2026-03-12T02:00:00.000Z",
+      },
+    ]);
+
+    const result = await bootstrapForgejoIssuesToTasks({
+      binding,
+      ...target,
+      issueClient,
+      linkStore,
+      since: "2026-03-12T01:00:00.000Z",
+      importClosedOnBootstrap: true,
+    });
+
+    expect(result.tasks).toHaveLength(0);
+    expect(result.createdLinks).toHaveLength(0);
+  });
+
   it("skips done and canceled tasks during export (no new issue created)", async () => {
     const issueClient = createInMemoryForgejoIssueClient();
     const linkStore = createInMemoryForgejoItemLinkStore();

--- a/src/forgejo-bootstrap.ts
+++ b/src/forgejo-bootstrap.ts
@@ -51,6 +51,7 @@ export async function bootstrapForgejoIssuesToTasks(input: {
   issueClient: ForgejoIssueClient;
   linkStore: ForgejoItemLinkStore;
   since?: string;
+  importClosedOnBootstrap?: boolean;
 }): Promise<ForgejoBootstrapImportResult> {
   const issues = await input.issueClient.listIssues(
     {
@@ -64,6 +65,8 @@ export async function bootstrapForgejoIssuesToTasks(input: {
 
   const tasks: ExternalTask[] = [];
   const createdLinks: ForgejoItemLink[] = [];
+  const shouldImportClosedIssuesOnBootstrap =
+    input.importClosedOnBootstrap === true && !input.since;
 
   for (const issue of issues) {
     if (issue.isPullRequest) {
@@ -71,7 +74,7 @@ export async function bootstrapForgejoIssuesToTasks(input: {
     }
 
     const existingLink = input.linkStore.getByIssueNumber(input.binding.id, issue.number);
-    if (!existingLink && issue.state !== "open") {
+    if (!existingLink && issue.state !== "open" && !shouldImportClosedIssuesOnBootstrap) {
       continue;
     }
 

--- a/src/forgejo-provider.test.ts
+++ b/src/forgejo-provider.test.ts
@@ -162,6 +162,64 @@ describe("forgejo provider runtime integration", () => {
     expect(state!.lastError).toBeNull();
   });
 
+  it("imports closed issues and their comments on initial bootstrap when the binding option is enabled", async () => {
+    const issueClient = createInMemoryForgejoIssueClient();
+    issueClient.seedIssues(target, [
+      {
+        number: 7,
+        externalId: "https://code.example.com/acme/roadmap#7",
+        title: "Closed issue",
+        state: "closed",
+        labels: ["status:done", "priority:high"],
+        assignees: [],
+        createdAt: "2026-03-12T00:00:00.000Z",
+        updatedAt: "2026-03-12T01:00:00.000Z",
+      },
+    ]);
+    issueClient.seedComments(target, 7, [
+      {
+        id: 11,
+        issueNumber: 7,
+        body: "Imported comment body",
+        author: "alice",
+        createdAt: "2026-03-12T01:30:00.000Z",
+        updatedAt: "2026-03-12T01:45:00.000Z",
+      },
+    ]);
+
+    const provider = createForgejoSyncProvider({
+      issueClient,
+      linkStore: createInMemoryForgejoItemLinkStore(),
+      runtimeStore: createInMemoryForgejoBindingRuntimeStore(),
+    });
+
+    await provider.initialize({
+      settings: {
+        baseUrl: target.baseUrl,
+        token: "secret-token",
+      },
+    });
+
+    const result = await provider.pull(
+      createBinding({ options: { importClosedOnBootstrap: true } }),
+      project
+    );
+
+    expect(result.tasks).toHaveLength(1);
+    expect(result.tasks[0]).toMatchObject({
+      title: "Closed issue",
+      status: "done",
+      priority: "high",
+    });
+    expect(result.comments).toHaveLength(1);
+    expect(result.comments?.[0]).toMatchObject({
+      externalId: "11",
+      author: "alice",
+    });
+    expect(result.comments?.[0].body).toContain("Imported comment body");
+    expect(provider.getState().commentLinks).toHaveLength(1);
+  });
+
   it("records failure in runtime store when pull throws", async () => {
     const issueClient = createInMemoryForgejoIssueClient();
     issueClient.listIssues = async () => {

--- a/src/forgejo-provider.ts
+++ b/src/forgejo-provider.ts
@@ -275,6 +275,7 @@ export function createForgejoSyncProvider(
           issueClient,
           linkStore,
           since: runtimeState.cursor ?? runtimeState.lastSuccessAt ?? undefined,
+          importClosedOnBootstrap: getImportClosedOnBootstrap(binding),
         });
 
         const pullCommentsResult = await pullComments({
@@ -523,6 +524,10 @@ export interface ForgejoSyncErrorClassification {
   kind: "auth" | "permission" | "not-found" | "rate-limit" | "server" | "transport" | "unknown";
   retryable: boolean;
   summary: string;
+}
+
+export function getImportClosedOnBootstrap(binding: IntegrationBinding): boolean {
+  return binding.options?.importClosedOnBootstrap === true;
 }
 
 export function classifyForgejoSyncError(error: unknown): ForgejoSyncErrorClassification {


### PR DESCRIPTION
## Summary
- add per-binding `importClosedOnBootstrap` handling via `binding.options`
- import unlinked closed Forgejo issues only during initial bootstrap when opt-in is enabled
- verify imported closed issues reuse existing comment pull behavior and preserve timestamps

## Testing
- npm run format
- npm run lint
- npm run typecheck
- npm test
- ./scripts/pre-pr.sh

## Manual verification
- upgraded dev `toduai` to `0.9.0`
- created `homelab` project and Forgejo integration for `erik/homelab` with `--options {"importClosedOnBootstrap":true}` via `make dev-cli`
- confirmed closed issues imported, imported comments were present, and imported tasks preserved Forgejo created/updated timestamps

Task: #task-acabce8c
Closes #16