### PR TITLE
fix: align forgejo comment sync with github

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -273,17 +273,17 @@ Keep the same logical stores as the GitHub plugin:
 
 ## Task / issue mapping
 
-| todu             | Forgejo                      | Notes                        |
-| ---------------- | ---------------------------- | ---------------------------- |
-| Task             | Issue                        | 1:1 link once bound          |
-| Title            | Title                        | bidirectional                |
-| Description      | Body                         | markdown on both sides       |
-| Status           | Issue state + reserved label | same scheme as GitHub plugin |
-| Priority         | Reserved label               | same scheme as GitHub plugin |
-| Labels           | Labels                       | non-reserved only            |
-| Comments / notes | Issue comments               | strict 1:1 mirror            |
-| Assignees        | Assignees                    | import only in v1            |
-| Due date         | none                         | stays local to todu          |
+| todu             | Forgejo                      | Notes                                          |
+| ---------------- | ---------------------------- | ---------------------------------------------- |
+| Task             | Issue                        | 1:1 link once bound                            |
+| Title            | Title                        | bidirectional                                  |
+| Description      | Body                         | markdown on both sides                         |
+| Status           | Issue state + reserved label | same scheme as GitHub plugin                   |
+| Priority         | Reserved label               | same scheme as GitHub plugin                   |
+| Labels           | Labels                       | non-reserved only                              |
+| Comments / notes | Issue comments               | mirrored create/edit; deletes do not propagate |
+| Assignees        | Assignees                    | import only in v1                              |
+| Due date         | none                         | stays local to todu                            |
 
 ## Status mapping
 
@@ -351,12 +351,12 @@ If an instance only supports one assignee, the plugin should treat it as a one-e
 
 ## Comments / notes
 
-Use the same strict mirrored model as `todu-github-plugin`:
+Use the same mirrored comment model as the current `todu-github-plugin`:
 
-- one Forgejo comment ↔ one todu note
+- one Forgejo comment ↔ one todu note when linked
 - create syncs both ways
 - edit syncs both ways
-- delete syncs both ways
+- mirrored comment deletes do not propagate in either direction
 
 Use visible attribution headers, unchanged except for the provider name:
 
@@ -425,8 +425,8 @@ Each polling cycle processes the binding according to strategy:
 - list issues updated since the last successful checkpoint
 - refresh linked item field state
 - discover newly created open issues
-- list comments for linked issues
-- mirror comment creates/edits/deletes into todu
+- list comments for changed linked issues, optionally constrained by a comment `since` checkpoint when deletion detection is not required
+- mirror comment creates/edits into todu
 - normalize reserved labels/state if needed
 
 ### Push path
@@ -434,7 +434,7 @@ Each polling cycle processes the binding according to strategy:
 - inspect local task changes supplied by the host
 - create issues for newly eligible unlinked tasks
 - update linked issues when task state wins conflict resolution
-- create/update/delete mirrored comments
+- create/update mirrored comments
 - update links and loop-prevention bookkeeping
 
 ## Conflict Resolution
@@ -462,7 +462,7 @@ Deletion or disappearance of the linked issue/task maps to cancelation:
 - Forgejo issue target becomes closed + `status:canceled`
 - todu task target becomes `canceled`
 
-Comments remain the exception: mirrored comment deletes propagate as hard deletes to preserve 1:1 comment state.
+Comments no longer remain the exception. Mirrored comment deletes do not propagate across systems. A deleted Forgejo comment or deleted todu note leaves the opposite side intact, which keeps steady-state sync incremental and avoids deletion-driven full comment scans.
 
 ## Polling, Retry, and Observability
 
@@ -771,7 +771,7 @@ The architecture is satisfied when the implementation can support all of the fol
 3. bootstrap imports open Forgejo issues and exports active/inprogress/waiting todu tasks
 4. linked items receive globally unique Forgejo-aware `external_id` values
 5. title/body/status/priority/labels sync bidirectionally according to the documented rules
-6. comments sync bidirectionally with strict 1:1 mirrored behavior
+6. comments sync bidirectionally for create/edit with non-propagating delete semantics
 7. Forgejo assignees import into todu
 8. polling, retry, and binding status behave independently per binding
 9. Forgejo-specific API/auth/rate-limit differences are isolated to config and client layers

--- a/docs/plans/phase-4-comment-sync.md
+++ b/docs/plans/phase-4-comment-sync.md
@@ -2,35 +2,35 @@
 
 ## Purpose
 
-Implement the strict 1:1 mirrored comment model from `../ARCHITECTURE.md`.
+Implement the mirrored comment model from `../ARCHITECTURE.md`.
 
-This phase should complete the user-visible sync behavior by handling comment creation, editing, deletion, attribution, and conflict resolution for Forgejo issue comments and todu notes.
+This phase should complete the user-visible sync behavior by handling comment creation, editing, attribution, and conflict resolution for Forgejo issue comments and todu notes while following the current GitHub-aligned non-propagating delete semantics.
 
 ## Scope
 
 - create mirrored comments in both directions
 - edit mirrored comments in both directions
-- hard delete mirrored comments in both directions
+- do not propagate mirrored comment deletes in either direction
 - maintain local comment link state
 - apply visible attribution headers in mirrored markdown comments
-- resolve comment edit conflicts with comment-level last-write-wins behavior
+- resolve comment edit conflicts with comment-level last-write-wins behavior where applicable
 - preserve Forgejo author identity in imported comment attribution
 
 ## Deliverables
 
 - comment mapping/link storage
-- comment create/edit/delete sync logic
+- comment create/edit sync logic
 - Forgejo/todu attribution formatting helpers
 - tests for comment lifecycle behavior and conflicts
 
 ## Acceptance Criteria
 
-- one Forgejo comment maps to one todu comment and vice versa
+- one Forgejo comment maps to one todu comment and vice versa when linked
 - mirrored comments include the expected attribution format
 - editing a comment on one side updates the mirrored comment on the other side
-- deleting a comment on one side deletes the mirrored comment on the other side
-- comment conflicts resolve according to the architecture rules
-- automated tests cover comment creation, edits, deletes, and conflict handling
+- deleting a comment on one side does not delete the mirrored comment on the other side
+- comment conflicts resolve according to the architecture rules in the supported sync model
+- automated tests cover comment creation, edits, non-propagating deletes, and conflict handling
 - automated tests cover attribution stripping so mirrored comments do not endlessly nest headers
 
 ## Out of Scope

--- a/src/forgejo-comments.test.ts
+++ b/src/forgejo-comments.test.ts
@@ -132,7 +132,7 @@ describe("forgejo comments", () => {
     });
   });
 
-  it("removes durable links for forgejo comments deleted remotely", async () => {
+  it("keeps durable links when forgejo comments are deleted remotely", async () => {
     const issueClient = createInMemoryForgejoIssueClient();
     const itemLinkStore = createInMemoryForgejoItemLinkStore();
     const commentLinkStore = createInMemoryForgejoCommentLinkStore();
@@ -167,8 +167,8 @@ describe("forgejo comments", () => {
       commentLinkStore,
     });
 
-    expect(result.deletedLinks).toEqual([existingLink]);
-    expect(commentLinkStore.getByForgejoCommentId(binding.id, 11)).toBeNull();
+    expect(result).toMatchObject({ comments: [], createdLinks: [] });
+    expect(commentLinkStore.getByForgejoCommentId(binding.id, 11)).toEqual(existingLink);
   });
 
   it("supports since-based comment pulls and touched issue filtering", async () => {
@@ -248,12 +248,11 @@ describe("forgejo comments", () => {
 
     expect(result.comments).toHaveLength(1);
     expect(result.comments[0].externalId).toBe("12");
-    expect(result.deletedLinks).toEqual([]);
     expect(commentLinkStore.getByForgejoCommentId(binding.id, 11)).not.toBeNull();
     expect(commentLinkStore.getByForgejoCommentId(binding.id, 21)).toBeNull();
   });
 
-  it("pushes local notes to forgejo, updates linked comments, and deletes removed comments", async () => {
+  it("pushes local notes to forgejo, updates linked comments, and leaves removed comments alone", async () => {
     const issueClient = createInMemoryForgejoIssueClient();
     const itemLinkStore = createInMemoryForgejoItemLinkStore();
     const commentLinkStore = createInMemoryForgejoCommentLinkStore();
@@ -282,7 +281,7 @@ describe("forgejo comments", () => {
       {
         id: 22,
         issueNumber: 7,
-        body: "Delete me",
+        body: "Keep me",
         author: "alice",
         createdAt: "2026-03-12T00:00:00.000Z",
         updatedAt: "2026-03-12T00:00:00.000Z",
@@ -316,7 +315,7 @@ describe("forgejo comments", () => {
       issueNumber: 7,
       forgejoCommentId: 22,
       lastMirroredAt: "2026-03-12T00:00:00.000Z",
-      lastMirroredBody: "Delete me",
+      lastMirroredBody: "Keep me",
     });
 
     const task = createTask(
@@ -339,6 +338,13 @@ describe("forgejo comments", () => {
       "2026-03-12T04:30:00.000Z"
     );
 
+    let listCommentsCalls = 0;
+    const originalListComments = issueClient.listComments.bind(issueClient);
+    issueClient.listComments = async (...args) => {
+      listCommentsCalls += 1;
+      return originalListComments(...args);
+    };
+
     const result = await pushComments({
       binding,
       issueClient,
@@ -348,6 +354,7 @@ describe("forgejo comments", () => {
       commentLinkStore,
     });
 
+    expect(listCommentsCalls).toBe(0);
     expect(result.updatedComments).toHaveLength(1);
     expect(result.updatedComments[0].id).toBe(21);
     expect(result.updatedComments[0].body).toBe(
@@ -357,14 +364,16 @@ describe("forgejo comments", () => {
     expect(result.createdComments[0].body).toBe(
       "_Synced from todu comment by @bob on 2026-03-12T04:00:00.000Z_\n\nBrand new local note"
     );
-    expect(result.deletedCommentIds).toEqual([22]);
     expect(commentLinkStore.getByNoteId(binding.id, createNoteId("note-new"))).toMatchObject({
       lastMirroredBody: "Brand new local note",
     });
     expect(commentLinkStore.getByNoteId(binding.id, createNoteId("note-existing"))).toMatchObject({
       lastMirroredBody: "Updated local body",
     });
-    expect(commentLinkStore.getByNoteId(binding.id, createNoteId("note-delete"))).toBeNull();
+    expect(commentLinkStore.getByNoteId(binding.id, createNoteId("note-delete"))).not.toBeNull();
+    expect(issueClient.snapshotComments(target, 7).map((comment) => comment.id)).toEqual([
+      21, 22, 23,
+    ]);
     expect(result.commentLinks).toHaveLength(2);
   });
 
@@ -450,7 +459,7 @@ describe("forgejo comments", () => {
     });
   });
 
-  it("lets newer remote comment changes win conflicts and ignores unlinked imported notes", async () => {
+  it("skips unchanged linked notes and ignores unlinked imported notes", async () => {
     const issueClient = createInMemoryForgejoIssueClient();
     const itemLinkStore = createInMemoryForgejoItemLinkStore();
     const commentLinkStore = createInMemoryForgejoCommentLinkStore();
@@ -494,8 +503,8 @@ describe("forgejo comments", () => {
       noteId: createNoteId("external:21"),
       issueNumber: 7,
       forgejoCommentId: 21,
-      lastMirroredAt: "2026-03-12T01:00:00.000Z",
-      lastMirroredBody: "Imported body",
+      lastMirroredAt: "2026-03-12T05:00:00.000Z",
+      lastMirroredBody: "Remote changed body",
     });
 
     const task = createTask(
@@ -504,7 +513,7 @@ describe("forgejo comments", () => {
           id: createNoteId("external:21"),
           content: formatAttributedBody(
             formatForgejoAttribution("alice", "2026-03-12T00:00:00.000Z"),
-            "Local conflicting edit"
+            "Remote changed body"
           ),
           author: "alice",
           tags: [],
@@ -535,7 +544,6 @@ describe("forgejo comments", () => {
 
     expect(result.updatedComments).toHaveLength(0);
     expect(result.createdComments).toHaveLength(0);
-    expect(result.deletedCommentIds).toHaveLength(0);
     expect(result.commentLinks).toHaveLength(1);
     expect(commentLinkStore.getByNoteId(binding.id, createNoteId("external:21"))).toMatchObject({
       lastMirroredBody: "Remote changed body",

--- a/src/forgejo-comments.ts
+++ b/src/forgejo-comments.ts
@@ -15,6 +15,7 @@ const FORGEJO_ATTRIBUTION_PREFIX = "_Synced from Forgejo comment by @";
 const TODU_ATTRIBUTION_PREFIX = "_Synced from todu comment by @";
 const ATTRIBUTION_SUFFIX_PATTERN = / on \d{4}-\d{2}-\d{2}T[\d:.]+Z_$/;
 const IMPORTED_COMMENT_LINK_PREFIX = "external:";
+const SYNC_EXTERNAL_ID_TAG_PREFIX = "sync:externalId:";
 
 export function formatForgejoAttribution(author: string, timestamp: string): string {
   return `_Synced from Forgejo comment by @${author} on ${timestamp}_`;
@@ -54,14 +55,13 @@ export function hasForgejoAttribution(body: string): boolean {
   );
 }
 
-function isImportedCommentLink(link: ForgejoCommentLink): boolean {
-  return (link.noteId as string).startsWith(IMPORTED_COMMENT_LINK_PREFIX);
+function hasImportedForgejoSyncTag(note: Note): boolean {
+  return note.tags.some((tag) => tag.startsWith(SYNC_EXTERNAL_ID_TAG_PREFIX));
 }
 
 export interface PullCommentsResult {
   comments: ExternalComment[];
   createdLinks: ForgejoCommentLink[];
-  deletedLinks: ForgejoCommentLink[];
 }
 
 export async function pullComments(input: {
@@ -80,7 +80,6 @@ export async function pullComments(input: {
 }): Promise<PullCommentsResult> {
   const comments: ExternalComment[] = [];
   const createdLinks: ForgejoCommentLink[] = [];
-  const deletedLinks: ForgejoCommentLink[] = [];
 
   const issueNumbers = input.issueNumbers ? new Set(input.issueNumbers) : null;
   const itemLinks = input.itemLinkStore
@@ -93,24 +92,6 @@ export async function pullComments(input: {
       itemLink.issueNumber,
       input.since ? { since: input.since } : undefined
     );
-    const existingCommentLinks = input.commentLinkStore.listByIssue(
-      input.binding.id,
-      itemLink.issueNumber
-    );
-
-    if (!input.since) {
-      const forgejoCommentIds = new Set(forgejoComments.map((comment) => comment.id));
-
-      for (const commentLink of existingCommentLinks) {
-        if (!forgejoCommentIds.has(commentLink.forgejoCommentId)) {
-          input.commentLinkStore.removeByForgejoCommentId(
-            input.binding.id,
-            commentLink.forgejoCommentId
-          );
-          deletedLinks.push(commentLink);
-        }
-      }
-    }
 
     for (const forgejoComment of forgejoComments) {
       const strippedBody = stripAttribution(forgejoComment.body);
@@ -157,14 +138,13 @@ export async function pullComments(input: {
     }
   }
 
-  return { comments, createdLinks, deletedLinks };
+  return { comments, createdLinks };
 }
 
 export interface PushCommentsResult {
   commentLinks: SyncProviderPushCommentLink[];
   createdComments: ForgejoComment[];
   updatedComments: ForgejoComment[];
-  deletedCommentIds: number[];
 }
 
 export async function pushComments(input: {
@@ -183,7 +163,6 @@ export async function pushComments(input: {
   const commentLinks: SyncProviderPushCommentLink[] = [];
   const createdComments: ForgejoComment[] = [];
   const updatedComments: ForgejoComment[] = [];
-  const deletedCommentIds: number[] = [];
 
   for (const task of input.tasks) {
     const itemLink = input.itemLinkStore.getByTaskId(input.binding.id, task.id);
@@ -191,67 +170,46 @@ export async function pushComments(input: {
       continue;
     }
 
-    const remoteComments = await input.issueClient.listComments(input.target, itemLink.issueNumber);
-    const remoteCommentsById = new Map(remoteComments.map((comment) => [comment.id, comment]));
-    const existingCommentLinks = input.commentLinkStore.listByTask(input.binding.id, task.id);
-    const currentNoteIds = new Set(task.comments.map((comment) => comment.id));
-
-    for (const commentLink of existingCommentLinks) {
-      if (!currentNoteIds.has(commentLink.noteId) && !isImportedCommentLink(commentLink)) {
-        await deleteForgejoComment(input, commentLink, deletedCommentIds);
-      }
-    }
+    const localTaskId = task.id;
 
     for (const note of task.comments) {
       const existingLink = input.commentLinkStore.getByNoteId(input.binding.id, note.id);
 
-      if (!existingLink) {
-        if (hasForgejoAttribution(note.content)) {
-          continue;
-        }
+      if (
+        !existingLink &&
+        (hasForgejoAttribution(note.content) || hasImportedForgejoSyncTag(note))
+      ) {
+        continue;
+      }
 
-        const createdComment = await createForgejoCommentFromNote(
+      if (existingLink) {
+        const updated = await updateForgejoCommentIfNeeded(
+          input,
+          note,
+          existingLink,
+          itemLink,
+          updatedComments
+        );
+        commentLinks.push(
+          createPushCommentLink(note.id, localTaskId, existingLink.forgejoCommentId, updated)
+        );
+      } else {
+        const created = await createForgejoCommentFromNote(
           input,
           note,
           task,
           itemLink,
           createdComments
         );
-        commentLinks.push(
-          createPushCommentLink(note.id, String(task.id), createdComment.id, createdComment)
-        );
-        continue;
+        commentLinks.push(createPushCommentLink(note.id, localTaskId, created.id, created));
       }
-
-      const updatedComment = await syncExistingForgejoComment({
-        binding: input.binding,
-        issueClient: input.issueClient,
-        target: input.target,
-        task,
-        note,
-        itemLink,
-        existingLink,
-        remoteComment: remoteCommentsById.get(existingLink.forgejoCommentId) ?? null,
-        commentLinkStore: input.commentLinkStore,
-        updatedComments,
-        createdComments,
-      });
-
-      commentLinks.push(
-        createPushCommentLink(
-          note.id,
-          String(task.id),
-          updatedComment?.id ?? existingLink.forgejoCommentId,
-          updatedComment
-        )
-      );
     }
   }
 
-  return { commentLinks, createdComments, updatedComments, deletedCommentIds };
+  return { commentLinks, createdComments, updatedComments };
 }
 
-async function deleteForgejoComment(
+async function updateForgejoCommentIfNeeded(
   input: {
     binding: IntegrationBinding;
     issueClient: ForgejoIssueClient;
@@ -263,101 +221,43 @@ async function deleteForgejoComment(
     };
     commentLinkStore: ForgejoCommentLinkStore;
   },
-  commentLink: ForgejoCommentLink,
-  deletedCommentIds: number[]
-): Promise<void> {
-  try {
-    await input.issueClient.deleteComment(input.target, commentLink.forgejoCommentId);
-  } catch {
-    // Comment may already be deleted remotely; proceed with local link cleanup.
-  }
-
-  input.commentLinkStore.remove(input.binding.id, commentLink.noteId);
-  deletedCommentIds.push(commentLink.forgejoCommentId);
-}
-
-async function syncExistingForgejoComment(input: {
-  binding: IntegrationBinding;
-  issueClient: ForgejoIssueClient;
-  target: {
-    baseUrl: string;
-    apiBaseUrl: string;
-    owner: string;
-    repo: string;
-  };
-  task: TaskPushPayload;
-  note: Note;
-  itemLink: ForgejoItemLink;
-  existingLink: ForgejoCommentLink;
-  remoteComment: ForgejoComment | null;
-  commentLinkStore: ForgejoCommentLinkStore;
-  updatedComments: ForgejoComment[];
-  createdComments: ForgejoComment[];
-}): Promise<ForgejoComment | null> {
-  const localBody = stripAttribution(input.note.content);
-  const remoteBody = input.remoteComment ? stripAttribution(input.remoteComment.body) : null;
-  const mirroredBody = input.existingLink.lastMirroredBody ?? remoteBody ?? localBody;
-  const localChanged = localBody !== mirroredBody;
-  const remoteChanged = remoteBody !== null && remoteBody !== mirroredBody;
-  const localObservedAt = getLocalObservedAt(input.note);
-
-  if (!localChanged) {
-    if (input.remoteComment && input.existingLink.lastMirroredBody !== remoteBody) {
-      input.commentLinkStore.save({
-        ...input.existingLink,
-        lastMirroredAt: input.remoteComment.updatedAt ?? input.remoteComment.createdAt,
-        lastMirroredBody: remoteBody ?? input.existingLink.lastMirroredBody,
-      });
-    }
-
-    return null;
-  }
+  note: Note,
+  existingLink: ForgejoCommentLink,
+  _itemLink: ForgejoItemLink,
+  updatedComments: ForgejoComment[]
+): Promise<ForgejoComment | null> {
+  const localBody = stripAttribution(note.content);
+  const mirroredBody = existingLink.lastMirroredBody ?? localBody;
+  const noteUpdatedAt = Date.parse(note.createdAt);
+  const lastMirroredAt = Date.parse(existingLink.lastMirroredAt);
 
   if (
-    input.remoteComment &&
-    remoteChanged &&
-    remoteWinsConflict(input.remoteComment, localObservedAt)
+    localBody === mirroredBody &&
+    !Number.isNaN(noteUpdatedAt) &&
+    !Number.isNaN(lastMirroredAt) &&
+    noteUpdatedAt <= lastMirroredAt
   ) {
-    input.commentLinkStore.save({
-      ...input.existingLink,
-      lastMirroredAt: input.remoteComment.updatedAt ?? input.remoteComment.createdAt,
-      lastMirroredBody: remoteBody ?? input.existingLink.lastMirroredBody,
-    });
     return null;
   }
 
-  if (!input.remoteComment) {
-    const recreatedComment = await createForgejoCommentFromNote(
-      {
-        binding: input.binding,
-        issueClient: input.issueClient,
-        target: input.target,
-        commentLinkStore: input.commentLinkStore,
-      },
-      input.note,
-      input.task,
-      input.itemLink,
-      input.createdComments,
-      input.existingLink
-    );
-
-    return recreatedComment;
+  if (localBody === mirroredBody) {
+    return null;
   }
 
   const attributedBody = formatAttributedBody(
-    formatToduAttribution(input.note.author, input.note.createdAt),
+    formatToduAttribution(note.author, note.createdAt),
     localBody
   );
 
   const updatedComment = await input.issueClient.updateComment(
     input.target,
-    input.existingLink.forgejoCommentId,
+    existingLink.forgejoCommentId,
     attributedBody
   );
 
-  input.updatedComments.push(updatedComment);
+  updatedComments.push(updatedComment);
   input.commentLinkStore.save({
-    ...input.existingLink,
+    ...existingLink,
     lastMirroredAt: updatedComment.updatedAt ?? updatedComment.createdAt,
     lastMirroredBody: localBody,
   });
@@ -380,8 +280,7 @@ async function createForgejoCommentFromNote(
   note: Note,
   task: TaskPushPayload,
   itemLink: ForgejoItemLink,
-  createdComments: ForgejoComment[],
-  existingLink?: ForgejoCommentLink
+  createdComments: ForgejoComment[]
 ): Promise<ForgejoComment> {
   const localBody = stripAttribution(note.content);
   const attributedBody = formatAttributedBody(
@@ -396,10 +295,6 @@ async function createForgejoCommentFromNote(
   );
 
   createdComments.push(createdComment);
-
-  if (existingLink) {
-    input.commentLinkStore.remove(input.binding.id, existingLink.noteId);
-  }
 
   input.commentLinkStore.save({
     bindingId: input.binding.id,
@@ -429,19 +324,4 @@ function createPushCommentLink(
     updatedAt: comment?.updatedAt,
     raw: comment,
   };
-}
-
-function getLocalObservedAt(note: Note): string {
-  return note.createdAt;
-}
-
-function remoteWinsConflict(remoteComment: ForgejoComment, localObservedAt: string): boolean {
-  const remoteObservedAt = Date.parse(remoteComment.updatedAt ?? remoteComment.createdAt);
-  const localObservedAtMs = Date.parse(localObservedAt);
-
-  if (Number.isNaN(remoteObservedAt) || Number.isNaN(localObservedAtMs)) {
-    return false;
-  }
-
-  return remoteObservedAt > localObservedAtMs;
 }

--- a/src/forgejo-provider.test.ts
+++ b/src/forgejo-provider.test.ts
@@ -305,16 +305,18 @@ describe("forgejo provider runtime integration", () => {
       },
     ]);
 
-    const listCommentsCalls: number[] = [];
+    const listCommentsCalls: Array<{ issueNumber: number; since?: string }> = [];
     const originalListComments = issueClient.listComments.bind(issueClient);
     issueClient.listComments = async (bindingTarget, issueNumber, options) => {
-      listCommentsCalls.push(issueNumber);
+      listCommentsCalls.push({ issueNumber, since: options?.since });
       return originalListComments(bindingTarget, issueNumber, options);
     };
 
     await provider.pull(createBinding(), project);
 
-    expect(listCommentsCalls).toEqual([7]);
+    expect(listCommentsCalls).toHaveLength(1);
+    expect(listCommentsCalls[0].issueNumber).toBe(7);
+    expect(listCommentsCalls[0].since).toEqual(expect.any(String));
   });
 
   it("records failure in runtime store when pull throws", async () => {

--- a/src/forgejo-provider.ts
+++ b/src/forgejo-provider.ts
@@ -285,6 +285,7 @@ export function createForgejoSyncProvider(
           itemLinkStore: linkStore,
           commentLinkStore,
           issueNumbers: lastPullResult.touchedIssueNumbers,
+          since: runtimeState.lastSuccessAt ?? undefined,
         });
 
         const cursor = new Date().toISOString();

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ export {
   type ForgejoIssueClient,
   type ForgejoRepositoryTarget as ForgejoClientRepositoryTarget,
   type InMemoryForgejoIssueClient,
+  type ListForgejoCommentsOptions,
   type ListForgejoIssuesOptions,
   type UpdateForgejoIssueInput,
 } from "@/forgejo-client";


### PR DESCRIPTION
## Summary
- remove mirrored comment delete propagation to match the current GitHub plugin direction
- eliminate deletion-driven remote comment scans and push-side remote comment prefetching
- update architecture/docs to reflect the new create/edit-only mirrored comment model

## Notes
- pull-side comment sync now safely uses incremental `since` behavior under the new deletion semantics
- create/edit mirroring remains intact for linked comments and notes
- this intentionally changes the previous strict mirrored comment deletion model

## Testing
- ./scripts/pre-pr.sh

Task: task-fad05c80
