### PR TITLE
fix: handle deleted tasks in forgejo push

### DIFF
--- a/src/forgejo-bootstrap.test.ts
+++ b/src/forgejo-bootstrap.test.ts
@@ -357,4 +357,140 @@ describe("forgejo bootstrap", () => {
 
     expect(listLabelsCalls).toBe(1);
   });
+
+  it("closes orphaned linked issues and removes their links", async () => {
+    const issueClient = createInMemoryForgejoIssueClient();
+    const linkStore = createInMemoryForgejoItemLinkStore();
+    const orphanedTaskId = createTaskId("task-orphaned");
+
+    issueClient.seedIssues(target, [
+      {
+        number: 11,
+        externalId: "https://forgejo.caradoc.com/erik/todu-forgejo-plugin-test#11",
+        title: "Orphaned issue",
+        state: "open",
+        labels: ["bug", "status:active", "priority:medium"],
+        assignees: [],
+        createdAt: "2026-03-12T00:00:00.000Z",
+        updatedAt: "2026-03-12T01:00:00.000Z",
+      },
+    ]);
+    linkStore.save({
+      bindingId: binding.id,
+      taskId: orphanedTaskId,
+      issueNumber: 11,
+      externalId: "https://forgejo.caradoc.com/erik/todu-forgejo-plugin-test#11",
+      lastMirroredAt: "2026-03-12T01:00:00.000Z",
+    });
+
+    const result = await bootstrapTasksToForgejoIssues({
+      binding,
+      baseUrl: target.baseUrl,
+      apiBaseUrl: target.apiBaseUrl,
+      owner: target.owner,
+      repo: target.repo,
+      tasks: [],
+      issueClient,
+      linkStore,
+    });
+
+    expect(result.closedIssues).toHaveLength(1);
+    expect(result.closedIssues[0]).toMatchObject({
+      number: 11,
+      state: "closed",
+      labels: ["bug", "priority:medium", "status:canceled"],
+    });
+    expect(result.issueReadCount).toBe(1);
+    expect(linkStore.getByTaskId(binding.id, orphanedTaskId)).toBeNull();
+  });
+
+  it("skips redundant close calls for already-closed orphaned issues and removes their links", async () => {
+    const issueClient = createInMemoryForgejoIssueClient();
+    const linkStore = createInMemoryForgejoItemLinkStore();
+    const orphanedTaskId = createTaskId("task-orphaned");
+
+    issueClient.seedIssues(target, [
+      {
+        number: 12,
+        externalId: "https://forgejo.caradoc.com/erik/todu-forgejo-plugin-test#12",
+        title: "Closed orphaned issue",
+        state: "closed",
+        labels: ["status:done", "priority:medium"],
+        assignees: [],
+        createdAt: "2026-03-12T00:00:00.000Z",
+        updatedAt: "2026-03-12T01:00:00.000Z",
+      },
+    ]);
+    linkStore.save({
+      bindingId: binding.id,
+      taskId: orphanedTaskId,
+      issueNumber: 12,
+      externalId: "https://forgejo.caradoc.com/erik/todu-forgejo-plugin-test#12",
+      lastMirroredAt: "2026-03-12T01:00:00.000Z",
+    });
+
+    let updateIssueCalls = 0;
+    const originalUpdateIssue = issueClient.updateIssue.bind(issueClient);
+    issueClient.updateIssue = async (...args) => {
+      updateIssueCalls += 1;
+      return originalUpdateIssue(...args);
+    };
+
+    const result = await bootstrapTasksToForgejoIssues({
+      binding,
+      baseUrl: target.baseUrl,
+      apiBaseUrl: target.apiBaseUrl,
+      owner: target.owner,
+      repo: target.repo,
+      tasks: [],
+      issueClient,
+      linkStore,
+    });
+
+    expect(result.closedIssues).toEqual([]);
+    expect(result.issueReadCount).toBe(1);
+    expect(updateIssueCalls).toBe(0);
+    expect(linkStore.getByTaskId(binding.id, orphanedTaskId)).toBeNull();
+  });
+
+  it("keeps orphaned links when loop prevention skips deletion-driven closes", async () => {
+    const issueClient = createInMemoryForgejoIssueClient();
+    const linkStore = createInMemoryForgejoItemLinkStore();
+    const orphanedTaskId = createTaskId("task-orphaned");
+
+    issueClient.seedIssues(target, [
+      {
+        number: 13,
+        externalId: "https://forgejo.caradoc.com/erik/todu-forgejo-plugin-test#13",
+        title: "Loop-protected orphaned issue",
+        state: "open",
+        labels: ["status:active", "priority:medium"],
+        assignees: [],
+        createdAt: "2026-03-12T00:00:00.000Z",
+        updatedAt: "2026-03-12T01:00:00.000Z",
+      },
+    ]);
+    linkStore.save({
+      bindingId: binding.id,
+      taskId: orphanedTaskId,
+      issueNumber: 13,
+      externalId: "https://forgejo.caradoc.com/erik/todu-forgejo-plugin-test#13",
+      lastMirroredAt: "2026-03-12T01:00:00.000Z",
+    });
+
+    const result = await bootstrapTasksToForgejoIssues({
+      binding,
+      baseUrl: target.baseUrl,
+      apiBaseUrl: target.apiBaseUrl,
+      owner: target.owner,
+      repo: target.repo,
+      tasks: [],
+      issueClient,
+      linkStore,
+      shouldSkipIssueUpdate: () => true,
+    });
+
+    expect(result.closedIssues).toEqual([]);
+    expect(linkStore.getByTaskId(binding.id, orphanedTaskId)).not.toBeNull();
+  });
 });

--- a/src/forgejo-bootstrap.ts
+++ b/src/forgejo-bootstrap.ts
@@ -39,6 +39,7 @@ export interface ForgejoBootstrapTaskUpdate {
 export interface ForgejoBootstrapExportResult {
   createdIssues: ForgejoIssue[];
   updatedIssues: ForgejoIssue[];
+  closedIssues: ForgejoIssue[];
   createdLinks: ForgejoItemLink[];
   taskUpdates: ForgejoBootstrapTaskUpdate[];
   hydratedLinkedTasks: number;
@@ -126,6 +127,7 @@ export async function bootstrapTasksToForgejoIssues(input: {
 }): Promise<ForgejoBootstrapExportResult> {
   const createdIssues: ForgejoIssue[] = [];
   const updatedIssues: ForgejoIssue[] = [];
+  const closedIssues: ForgejoIssue[] = [];
   const createdLinks: ForgejoItemLink[] = [];
   const taskUpdates: ForgejoBootstrapTaskUpdate[] = [];
   let hydratedLinkedTasks = 0;
@@ -273,14 +275,64 @@ export async function bootstrapTasksToForgejoIssues(input: {
     });
   }
 
+  const currentTaskIds = new Set(input.tasks.map((task) => task.id));
+  const orphanedLinks = input.linkStore
+    .list(input.binding.id)
+    .filter((link) => !currentTaskIds.has(link.taskId));
+
+  for (const orphanedLink of orphanedLinks) {
+    issueReadCount += 1;
+    const existingIssue = await input.issueClient.getIssue(target, orphanedLink.issueNumber);
+
+    if (!existingIssue) {
+      input.linkStore.remove(input.binding.id, orphanedLink.taskId);
+      continue;
+    }
+
+    if (input.shouldSkipIssueUpdate?.(existingIssue)) {
+      continue;
+    }
+
+    if (existingIssue.state === "closed") {
+      input.linkStore.remove(input.binding.id, orphanedLink.taskId);
+      continue;
+    }
+
+    const issueClose = createForgejoIssueCloseFromDeletion(existingIssue);
+    await ensureLabelsExist(issueClose.labels ?? []);
+    const closedIssue = await input.issueClient.updateIssue(
+      target,
+      orphanedLink.issueNumber,
+      issueClose
+    );
+    closedIssues.push(closedIssue);
+    input.linkStore.remove(input.binding.id, orphanedLink.taskId);
+  }
+
   return {
     createdIssues,
     updatedIssues,
+    closedIssues,
     createdLinks,
     taskUpdates,
     hydratedLinkedTasks,
     issueReadCount,
     skippedLinkedTasks,
+  };
+}
+
+function createForgejoIssueCloseFromDeletion(issue: ForgejoIssue): {
+  state: "closed";
+  labels: string[];
+} {
+  return {
+    state: "closed",
+    labels: [
+      ...new Set([
+        ...issue.labels.filter((label) => !label.startsWith("status:")),
+        "status:canceled",
+      ]),
+    ],
   };
 }
 

--- a/src/forgejo-links.ts
+++ b/src/forgejo-links.ts
@@ -24,6 +24,7 @@ export interface ForgejoItemLinkStore {
   list(bindingId: IntegrationBinding["id"]): ForgejoItemLink[];
   listAll(): ForgejoItemLink[];
   save(link: ForgejoItemLink): void;
+  remove(bindingId: IntegrationBinding["id"], taskId: Task["id"]): void;
 }
 
 export function createInMemoryForgejoItemLinkStore(): ForgejoItemLinkStore {
@@ -62,8 +63,25 @@ export function createInMemoryForgejoItemLinkStore(): ForgejoItemLinkStore {
       return [...allLinks.values()];
     },
     save(link): void {
+      const existingByTask = links.get(getTaskKey(link.bindingId, link.taskId));
+      if (existingByTask) {
+        links.delete(getIssueKey(link.bindingId, existingByTask.issueNumber));
+      }
+
+      const existingByIssue = links.get(getIssueKey(link.bindingId, link.issueNumber));
+      if (existingByIssue) {
+        links.delete(getTaskKey(link.bindingId, existingByIssue.taskId));
+      }
+
       links.set(getTaskKey(link.bindingId, link.taskId), link);
       links.set(getIssueKey(link.bindingId, link.issueNumber), link);
+    },
+    remove(bindingId, taskId): void {
+      const link = links.get(getTaskKey(bindingId, taskId));
+      if (link) {
+        links.delete(getTaskKey(bindingId, taskId));
+        links.delete(getIssueKey(bindingId, link.issueNumber));
+      }
     },
   };
 }
@@ -123,6 +141,12 @@ export function createFileForgejoItemLinkStore(storagePath: string): ForgejoItem
           )
       );
       existingLinks.push(link);
+      writeLinks(existingLinks);
+    },
+    remove(bindingId, taskId): void {
+      const existingLinks = readLinks().filter(
+        (link) => !(link.bindingId === bindingId && link.taskId === taskId)
+      );
       writeLinks(existingLinks);
     },
   };

--- a/src/forgejo-provider.test.ts
+++ b/src/forgejo-provider.test.ts
@@ -435,6 +435,61 @@ describe("forgejo provider runtime integration", () => {
     expect(writes[0].key).toContain("issue:");
   });
 
+  it("records closed orphaned issues in loop prevention and push summary logging", async () => {
+    const issueClient = createInMemoryForgejoIssueClient();
+    issueClient.seedIssues(target, [
+      {
+        number: 9,
+        externalId: "https://code.example.com/acme/roadmap#9",
+        title: "Deleted task issue",
+        state: "open",
+        labels: ["status:active", "priority:medium"],
+        assignees: [],
+        createdAt: "2026-03-12T00:00:00.000Z",
+        updatedAt: "2026-03-12T01:00:00.000Z",
+      },
+    ]);
+
+    const linkStore = createInMemoryForgejoItemLinkStore();
+    linkStore.save({
+      bindingId: createBinding().id,
+      taskId: createTaskId("task-deleted"),
+      issueNumber: 9,
+      externalId: "https://code.example.com/acme/roadmap#9",
+      lastMirroredAt: "2026-03-12T01:00:00.000Z",
+    });
+
+    const loopPreventionStore = createForgejoLoopPreventionStore();
+    const logger = createForgejoSyncLogger();
+    const provider = createForgejoSyncProvider({
+      issueClient,
+      linkStore,
+      loopPreventionStore,
+      logger,
+    });
+
+    await provider.initialize({
+      settings: {
+        baseUrl: target.baseUrl,
+        token: "secret-token",
+      },
+    });
+
+    await provider.push(createBinding(), [], project);
+
+    expect(provider.getState().lastPushResult).toMatchObject({
+      closedIssues: [expect.objectContaining({ number: 9, state: "closed" })],
+    });
+    expect(linkStore.getByTaskId(createBinding().id, createTaskId("task-deleted"))).toBeNull();
+    expect(loopPreventionStore.listAll()).toContainEqual(
+      expect.objectContaining({ key: `issue:${createBinding().id}:9` })
+    );
+    expect(logger.getEntries().at(-1)).toMatchObject({
+      message: "push completed",
+      context: expect.objectContaining({ itemId: expect.stringContaining("1 closed") }),
+    });
+  });
+
   it("reports skipped linked task push metrics without reading forgejo issues", async () => {
     const issueClient = createInMemoryForgejoIssueClient();
     const linkStore = createInMemoryForgejoItemLinkStore();

--- a/src/forgejo-provider.ts
+++ b/src/forgejo-provider.ts
@@ -323,6 +323,7 @@ export function createForgejoSyncProvider(
         lastPushResult = {
           createdIssues: [],
           updatedIssues: [],
+          closedIssues: [],
           createdLinks: [],
           taskUpdates: [],
           hydratedLinkedTasks: 0,
@@ -384,6 +385,13 @@ export function createForgejoSyncProvider(
           );
         }
 
+        for (const closedIssue of lastPushResult.closedIssues) {
+          loopPreventionStore.recordWrite(
+            createForgejoWriteKey("issue", String(binding.id), String(closedIssue.number)),
+            closedIssue.updatedAt ?? new Date().toISOString()
+          );
+        }
+
         const pushCommentsResult = await pushComments({
           binding,
           issueClient,
@@ -419,6 +427,7 @@ export function createForgejoSyncProvider(
           itemId:
             `${lastPushResult.createdIssues.length} created, ` +
             `${lastPushResult.updatedIssues.length} updated, ` +
+            `${lastPushResult.closedIssues.length} closed, ` +
             `${lastPushResult.skippedLinkedTasks} skipped, ` +
             `${lastPushResult.issueReadCount} issue reads, ` +
             `${pushCommentsResult.createdComments.length} comment creates, ` +


### PR DESCRIPTION
## Summary
- close orphaned linked Forgejo issues during push and remove their stale item links
- record closed issues in the bootstrap/push result and loop prevention bookkeeping
- include closed issue counts in push completion logging and cover the new behavior with tests

## Testing
- npm run format
- npm run lint
- npm run typecheck
- npm test -- src/forgejo-bootstrap.test.ts src/forgejo-provider.test.ts
- ./scripts/pre-pr.sh

Closes #18
Task: #task-66cae02b