### PR TITLE
fix: heal stale missing forgejo issue sync

### DIFF
--- a/src/forgejo-bootstrap.ts
+++ b/src/forgejo-bootstrap.ts
@@ -11,6 +11,7 @@ import {
   mapForgejoIssueToExternalTask,
 } from "@/forgejo-fields";
 import { parseForgejoIssueExternalId } from "@/forgejo-ids";
+import type { ForgejoCommentLinkStore } from "@/forgejo-comment-links";
 import {
   createLinkFromIssue,
   createLinkFromTask,
@@ -123,6 +124,7 @@ export async function bootstrapTasksToForgejoIssues(input: {
   tasks: TaskPushPayload[];
   issueClient: ForgejoIssueClient;
   linkStore: ForgejoItemLinkStore;
+  commentLinkStore?: ForgejoCommentLinkStore;
   shouldSkipIssueUpdate?: (issue: ForgejoIssue) => boolean;
 }): Promise<ForgejoBootstrapExportResult> {
   const createdIssues: ForgejoIssue[] = [];
@@ -152,101 +154,21 @@ export async function bootstrapTasksToForgejoIssues(input: {
     }
   };
 
-  for (const task of input.tasks) {
-    const existingLink = input.linkStore.getByTaskId(input.binding.id, task.id);
-    if (existingLink) {
-      task.externalId = existingLink.externalId;
-      task.sourceUrl ??= createForgejoIssueSourceUrl(target, existingLink.issueNumber);
+  const clearStaleTaskReferences = (taskId: TaskPushPayload["id"]): void => {
+    input.linkStore.remove(input.binding.id, taskId);
 
-      if (!existingLink.lastMirroredAt) {
-        issueReadCount += 1;
-        const existingIssue = await input.issueClient.getIssue(target, existingLink.issueNumber);
-        hydratedLinkedTasks += 1;
-        task.sourceUrl = existingIssue?.sourceUrl ?? task.sourceUrl;
-
-        if (existingIssue) {
-          const hydratedLink: ForgejoItemLink = {
-            ...existingLink,
-            lastMirroredAt: existingIssue.updatedAt ?? existingIssue.createdAt,
-          };
-          input.linkStore.save(hydratedLink);
-
-          if (!shouldPushTaskUpdate(task, existingIssue)) {
-            skippedLinkedTasks += 1;
-            continue;
-          }
-
-          if (input.shouldSkipIssueUpdate?.(existingIssue)) {
-            continue;
-          }
-        }
-      } else if (!shouldPushTaskUpdateFromMirroredAt(task, existingLink.lastMirroredAt)) {
-        skippedLinkedTasks += 1;
-        continue;
-      }
-
-      const issueUpdate = createForgejoIssueUpdateFromTask(task);
-      await ensureLabelsExist(issueUpdate.labels ?? []);
-      const updatedIssue = await input.issueClient.updateIssue(
-        target,
-        existingLink.issueNumber,
-        issueUpdate
-      );
-      task.sourceUrl = updatedIssue.sourceUrl;
-      input.linkStore.save({
-        ...existingLink,
-        lastMirroredAt: updatedIssue.updatedAt ?? updatedIssue.createdAt,
-      });
-      updatedIssues.push(updatedIssue);
-      continue;
+    if (!input.commentLinkStore) {
+      return;
     }
 
-    const matchingExternalId = getMatchingExternalId(task, input.baseUrl, input.owner, input.repo);
-    if (matchingExternalId) {
-      issueReadCount += 1;
-      const existingIssue = await input.issueClient.getIssue(
-        target,
-        matchingExternalId.issueNumber
-      );
-      const createdLink = createLinkFromTask({
-        binding: input.binding,
-        taskId: task.id,
-        baseUrl: input.baseUrl,
-        owner: input.owner,
-        repo: input.repo,
-        issueNumber: matchingExternalId.issueNumber,
-        lastMirroredAt: existingIssue?.updatedAt ?? existingIssue?.createdAt,
-      });
-      task.externalId = createdLink.externalId;
-      task.sourceUrl ??=
-        existingIssue?.sourceUrl ??
-        createForgejoIssueSourceUrl(target, matchingExternalId.issueNumber);
-      input.linkStore.save(createdLink);
-      createdLinks.push(createdLink);
-
-      if (
-        shouldPushTaskUpdate(task, existingIssue) &&
-        !(existingIssue && input.shouldSkipIssueUpdate?.(existingIssue))
-      ) {
-        const issueUpdate = createForgejoIssueUpdateFromTask(task);
-        await ensureLabelsExist(issueUpdate.labels ?? []);
-        const updatedIssue = await input.issueClient.updateIssue(
-          target,
-          matchingExternalId.issueNumber,
-          issueUpdate
-        );
-        task.sourceUrl = updatedIssue.sourceUrl;
-        input.linkStore.save({
-          ...createdLink,
-          lastMirroredAt: updatedIssue.updatedAt ?? updatedIssue.createdAt,
-        });
-        updatedIssues.push(updatedIssue);
-      }
-      continue;
+    for (const commentLink of input.commentLinkStore.listByTask(input.binding.id, taskId)) {
+      input.commentLinkStore.remove(input.binding.id, commentLink.noteId);
     }
+  };
 
+  const createIssueForTask = async (task: TaskPushPayload): Promise<boolean> => {
     if (!TASK_BOOTSTRAP_EXPORT_STATUSES.has(task.status)) {
-      continue;
+      return false;
     }
 
     const issueCreate = createForgejoIssueCreateFromTask(task);
@@ -273,6 +195,123 @@ export async function bootstrapTasksToForgejoIssues(input: {
       externalId: createdLink.externalId,
       sourceUrl: createdIssue.sourceUrl,
     });
+
+    return true;
+  };
+
+  for (const task of input.tasks) {
+    const existingLink = input.linkStore.getByTaskId(input.binding.id, task.id);
+    if (existingLink) {
+      task.externalId = existingLink.externalId;
+      task.sourceUrl ??= createForgejoIssueSourceUrl(target, existingLink.issueNumber);
+
+      if (!existingLink.lastMirroredAt) {
+        issueReadCount += 1;
+        const existingIssue = await input.issueClient.getIssue(target, existingLink.issueNumber);
+        hydratedLinkedTasks += 1;
+        task.sourceUrl = existingIssue?.sourceUrl ?? task.sourceUrl;
+
+        if (!existingIssue) {
+          clearStaleTaskReferences(task.id);
+          await createIssueForTask(task);
+          continue;
+        }
+
+        const hydratedLink: ForgejoItemLink = {
+          ...existingLink,
+          lastMirroredAt: existingIssue.updatedAt ?? existingIssue.createdAt,
+        };
+        input.linkStore.save(hydratedLink);
+
+        if (!shouldPushTaskUpdate(task, existingIssue)) {
+          skippedLinkedTasks += 1;
+          continue;
+        }
+
+        if (input.shouldSkipIssueUpdate?.(existingIssue)) {
+          continue;
+        }
+      } else if (!shouldPushTaskUpdateFromMirroredAt(task, existingLink.lastMirroredAt)) {
+        skippedLinkedTasks += 1;
+        continue;
+      }
+
+      const issueUpdate = createForgejoIssueUpdateFromTask(task);
+      await ensureLabelsExist(issueUpdate.labels ?? []);
+
+      try {
+        const updatedIssue = await input.issueClient.updateIssue(
+          target,
+          existingLink.issueNumber,
+          issueUpdate
+        );
+        task.sourceUrl = updatedIssue.sourceUrl;
+        input.linkStore.save({
+          ...existingLink,
+          lastMirroredAt: updatedIssue.updatedAt ?? updatedIssue.createdAt,
+        });
+        updatedIssues.push(updatedIssue);
+      } catch (error) {
+        if (!isForgejoIssueNotFoundError(error)) {
+          throw error;
+        }
+
+        clearStaleTaskReferences(task.id);
+        await createIssueForTask(task);
+      }
+      continue;
+    }
+
+    const matchingExternalId = getMatchingExternalId(task, input.baseUrl, input.owner, input.repo);
+    if (matchingExternalId) {
+      issueReadCount += 1;
+      const existingIssue = await input.issueClient.getIssue(
+        target,
+        matchingExternalId.issueNumber
+      );
+
+      if (!existingIssue) {
+        clearStaleTaskReferences(task.id);
+        await createIssueForTask(task);
+        continue;
+      }
+
+      const createdLink = createLinkFromTask({
+        binding: input.binding,
+        taskId: task.id,
+        baseUrl: input.baseUrl,
+        owner: input.owner,
+        repo: input.repo,
+        issueNumber: matchingExternalId.issueNumber,
+        lastMirroredAt: existingIssue.updatedAt ?? existingIssue.createdAt,
+      });
+      task.externalId = createdLink.externalId;
+      task.sourceUrl ??= existingIssue.sourceUrl;
+      input.linkStore.save(createdLink);
+      createdLinks.push(createdLink);
+
+      if (
+        shouldPushTaskUpdate(task, existingIssue) &&
+        !input.shouldSkipIssueUpdate?.(existingIssue)
+      ) {
+        const issueUpdate = createForgejoIssueUpdateFromTask(task);
+        await ensureLabelsExist(issueUpdate.labels ?? []);
+        const updatedIssue = await input.issueClient.updateIssue(
+          target,
+          matchingExternalId.issueNumber,
+          issueUpdate
+        );
+        task.sourceUrl = updatedIssue.sourceUrl;
+        input.linkStore.save({
+          ...createdLink,
+          lastMirroredAt: updatedIssue.updatedAt ?? updatedIssue.createdAt,
+        });
+        updatedIssues.push(updatedIssue);
+      }
+      continue;
+    }
+
+    await createIssueForTask(task);
   }
 
   const currentTaskIds = new Set(input.tasks.map((task) => task.id));
@@ -319,6 +358,11 @@ export async function bootstrapTasksToForgejoIssues(input: {
     issueReadCount,
     skippedLinkedTasks,
   };
+}
+
+function isForgejoIssueNotFoundError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /\b404\b/.test(message) || /issue not found/i.test(message);
 }
 
 function createForgejoIssueCloseFromDeletion(issue: ForgejoIssue): {

--- a/src/forgejo-comments.ts
+++ b/src/forgejo-comments.ts
@@ -64,6 +64,11 @@ export interface PullCommentsResult {
   createdLinks: ForgejoCommentLink[];
 }
 
+export interface PullCommentsIssueErrorContext {
+  itemLink: ForgejoItemLink;
+  error: unknown;
+}
+
 export async function pullComments(input: {
   binding: IntegrationBinding;
   issueClient: ForgejoIssueClient;
@@ -77,6 +82,9 @@ export async function pullComments(input: {
   commentLinkStore: ForgejoCommentLinkStore;
   issueNumbers?: readonly number[];
   since?: string;
+  onIssueError?: (
+    context: PullCommentsIssueErrorContext
+  ) => "continue" | "throw" | Promise<"continue" | "throw">;
 }): Promise<PullCommentsResult> {
   const comments: ExternalComment[] = [];
   const createdLinks: ForgejoCommentLink[] = [];
@@ -87,11 +95,22 @@ export async function pullComments(input: {
     .filter((itemLink) => issueNumbers?.has(itemLink.issueNumber) ?? true);
 
   for (const itemLink of itemLinks) {
-    const forgejoComments = await input.issueClient.listComments(
-      input.target,
-      itemLink.issueNumber,
-      input.since ? { since: input.since } : undefined
-    );
+    let forgejoComments: ForgejoComment[];
+
+    try {
+      forgejoComments = await input.issueClient.listComments(
+        input.target,
+        itemLink.issueNumber,
+        input.since ? { since: input.since } : undefined
+      );
+    } catch (error) {
+      const resolution = await input.onIssueError?.({ itemLink, error });
+      if (resolution === "continue") {
+        continue;
+      }
+
+      throw error;
+    }
 
     for (const forgejoComment of forgejoComments) {
       const strippedBody = stripAttribution(forgejoComment.body);

--- a/src/forgejo-provider-hardening.test.ts
+++ b/src/forgejo-provider-hardening.test.ts
@@ -1,14 +1,17 @@
 import {
   createIntegrationBindingId,
+  createNoteId,
   createProjectId,
   createTaskId,
   type IntegrationBinding,
   type TaskPushPayload,
 } from "@todu/core";
 
+import { createInMemoryForgejoCommentLinkStore } from "@/forgejo-comment-links";
 import { FORGEJO_PROVIDER_NAME, FORGEJO_REPOSITORY_TARGET_KIND } from "@/forgejo-binding";
 import { createInMemoryForgejoIssueClient } from "@/forgejo-client";
-import { createInMemoryForgejoItemLinkStore } from "@/forgejo-links";
+import { createForgejoSyncLogger } from "@/forgejo-logger";
+import { createLinkFromTask, createInMemoryForgejoItemLinkStore } from "@/forgejo-links";
 import { createForgejoSyncProvider } from "@/forgejo-provider";
 import { createInMemoryForgejoBindingRuntimeStore } from "@/forgejo-runtime";
 
@@ -203,6 +206,87 @@ describe("strategy-specific behavior", () => {
 });
 
 describe("provider error classification coverage", () => {
+  it("skips missing issue comment fetches, removes stale links, and logs a warning", async () => {
+    const issueClient = createInMemoryForgejoIssueClient();
+    issueClient.seedIssues(target, [
+      {
+        number: 7,
+        externalId: "https://code.example.com/acme/roadmap#7",
+        title: "Issue seven",
+        state: "open",
+        labels: ["status:active"],
+        assignees: [],
+        createdAt: "2026-03-12T00:00:00.000Z",
+        updatedAt: "2026-03-12T01:00:00.000Z",
+      },
+    ]);
+    issueClient.listComments = async (_target, issueNumber) => {
+      throw new Error(
+        `Forgejo API GET /repos/acme/roadmap/issues/${issueNumber}/comments failed: 404 issue does not exist`
+      );
+    };
+
+    const linkStore = createInMemoryForgejoItemLinkStore();
+    const logger = createForgejoSyncLogger();
+    const provider = await initProvider({
+      issueClient,
+      linkStore,
+      commentLinkStore: createInMemoryForgejoCommentLinkStore(),
+      logger,
+    });
+
+    const result = await provider.pull(createBinding(), project);
+
+    expect(result.tasks).toHaveLength(1);
+    expect(result.comments).toEqual([]);
+    expect(linkStore.getByIssueNumber(createBinding().id, 7)).toBeNull();
+    expect(logger.getEntries()).toContainEqual(
+      expect.objectContaining({
+        level: "warn",
+        message: "skipping comments for missing remote issue; stale links removed",
+        context: expect.objectContaining({
+          bindingId: createBinding().id,
+          direction: "pull",
+          entityType: "issue",
+          itemId: "7",
+        }),
+      })
+    );
+  });
+
+  it("keeps transient comment pull timeouts retryable", async () => {
+    const issueClient = createInMemoryForgejoIssueClient();
+    issueClient.seedIssues(target, [
+      {
+        number: 7,
+        externalId: "https://code.example.com/acme/roadmap#7",
+        title: "Issue seven",
+        state: "open",
+        labels: ["status:active"],
+        assignees: [],
+        createdAt: "2026-03-12T00:00:00.000Z",
+        updatedAt: "2026-03-12T01:00:00.000Z",
+      },
+    ]);
+    issueClient.listComments = async () => {
+      throw new Error("The operation timed out.");
+    };
+
+    const runtimeStore = createInMemoryForgejoBindingRuntimeStore();
+    const provider = await initProvider({
+      issueClient,
+      linkStore: createInMemoryForgejoItemLinkStore(),
+      runtimeStore,
+      retryConfig: { initialSeconds: 0, maxSeconds: 0 },
+    });
+
+    await expect(provider.pull(createBinding(), project)).rejects.toThrow("timed out");
+
+    const state = runtimeStore.get(createBinding().id);
+    expect(state!.lastError).toContain("transport error");
+    expect(state!.retryAttempt).toBe(1);
+  });
+
   it("classifies 404 as non-retryable not-found", async () => {
     const issueClient = createInMemoryForgejoIssueClient();
     issueClient.listIssues = async () => {
@@ -240,6 +324,71 @@ describe("provider error classification coverage", () => {
 });
 
 describe("provider push failure handling", () => {
+  it("recreates a missing remote issue for a stale local reference and remirrors comments", async () => {
+    const issueClient = createInMemoryForgejoIssueClient();
+    const linkStore = createInMemoryForgejoItemLinkStore();
+    const commentLinkStore = createInMemoryForgejoCommentLinkStore();
+
+    linkStore.save(
+      createLinkFromTask({
+        binding: createBinding(),
+        taskId: createTaskId("task-1"),
+        baseUrl: target.baseUrl,
+        owner: target.owner,
+        repo: target.repo,
+        issueNumber: 7,
+        lastMirroredAt: "2026-03-12T00:00:00.000Z",
+      })
+    );
+    commentLinkStore.save({
+      bindingId: createBinding().id,
+      taskId: createTaskId("task-1"),
+      noteId: createNoteId("note-1"),
+      issueNumber: 7,
+      forgejoCommentId: 11,
+      lastMirroredAt: "2026-03-12T00:00:00.000Z",
+      lastMirroredBody: "Old mirrored body",
+    });
+
+    const provider = await initProvider({
+      issueClient,
+      linkStore,
+      commentLinkStore,
+    });
+
+    const pushResult = await provider.push(
+      createBinding(),
+      [
+        createPushTask({
+          externalId: "https://code.example.com/acme/roadmap#7",
+          updatedAt: "2026-03-12T02:00:00.000Z",
+          comments: [
+            {
+              id: createNoteId("note-1"),
+              content: "Updated local note",
+              author: "alice",
+              createdAt: "2026-03-12T02:00:00.000Z",
+              tags: [],
+            },
+          ],
+        }),
+      ],
+      project
+    );
+
+    expect(issueClient.snapshotIssues(target)).toHaveLength(1);
+    expect(issueClient.snapshotComments(target, 1)).toHaveLength(1);
+    expect(issueClient.snapshotComments(target, 1)[0].body).toContain("Updated local note");
+    expect(pushResult.taskLinks).toHaveLength(1);
+    expect(pushResult.taskLinks[0].externalId).toBe("https://code.example.com/acme/roadmap#1");
+    expect(commentLinkStore.getByNoteId(createBinding().id, createNoteId("note-1"))).toMatchObject({
+      issueNumber: 1,
+      forgejoCommentId: 1,
+    });
+    expect(linkStore.getByIssueNumber(createBinding().id, 7)).toBeNull();
+    expect(linkStore.getByIssueNumber(createBinding().id, 1)).not.toBeNull();
+  });
+
   it("records failure state when push throws", async () => {
     const issueClient = createInMemoryForgejoIssueClient();
     issueClient.createIssue = async () => {

--- a/src/forgejo-provider.ts
+++ b/src/forgejo-provider.ts
@@ -183,6 +183,24 @@ export function createForgejoSyncProvider(
     return settings;
   };
 
+  const clearCommentLinksForIssue = (
+    bindingId: IntegrationBinding["id"],
+    issueNumber: number
+  ): void => {
+    for (const commentLink of commentLinkStore.listByIssue(bindingId, issueNumber)) {
+      commentLinkStore.remove(bindingId, commentLink.noteId);
+    }
+  };
+
+  const clearStaleIssueReferences = (input: {
+    bindingId: IntegrationBinding["id"];
+    issueNumber: number;
+    taskId: Task["id"];
+  }): void => {
+    clearCommentLinksForIssue(input.bindingId, input.issueNumber);
+    linkStore.remove(input.bindingId, input.taskId);
+  };
+
   const validateBinding = (
     binding: Parameters<SyncProvider["pull"]>[0]
   ): ForgejoRepositoryBinding => {
@@ -286,6 +304,24 @@ export function createForgejoSyncProvider(
           commentLinkStore,
           issueNumbers: lastPullResult.touchedIssueNumbers,
           since: runtimeState.lastSuccessAt ?? undefined,
+          onIssueError: ({ itemLink, error }) => {
+            const classification = classifyForgejoSyncError(error);
+            if (classification.kind !== "not-found") {
+              return "throw";
+            }
+
+            clearStaleIssueReferences({
+              bindingId: binding.id,
+              issueNumber: itemLink.issueNumber,
+              taskId: itemLink.taskId,
+            });
+            logger.warn("skipping comments for missing remote issue; stale links removed", {
+              ...logContext,
+              entityType: "issue",
+              itemId: String(itemLink.issueNumber),
+            });
+            return "continue";
+          },
         });
 
         const cursor = new Date().toISOString();
@@ -358,6 +394,7 @@ export function createForgejoSyncProvider(
           tasks,
           issueClient,
           linkStore,
+          commentLinkStore,
           shouldSkipIssueUpdate: (issue) => {
             const issueTimestamp = issue.updatedAt ?? issue.createdAt;
             if (!issueTimestamp) {


### PR DESCRIPTION
## Summary

- handle missing remote Forgejo issues during comment pulls as a non-fatal per-issue condition
- remove stale item/comment links when a linked remote issue is gone so the same missing issue is not retried every cycle
- heal stale local references on push by recreating the missing remote issue for open tasks and remirroring comments
- add regression coverage for missing-issue pulls, stale local references, and transient timeout handling

## Verification

- `./scripts/pre-pr.sh`
- `npm run build`
- live validation against the local daemon after restart
  - `todu integration status` showed the `vault` Forgejo binding returning to `idle` with successful syncs
  - `/home/erik/.config/todu/data/daemon.err.log` had no new missing-issue failures for `/issues/190/comments` or `/issues/198/comments`

Task: #task-4b162fe6
