### PR TITLE
Self-heal stale Forgejo comment links

### DIFF
--- a/src/forgejo-comments.test.ts
+++ b/src/forgejo-comments.test.ts
@@ -253,7 +253,7 @@ describe("forgejo comments", () => {
     expect(commentLinkStore.getByForgejoCommentId(binding.id, 21)).toBeNull();
   });
 
-  it("pushes local notes to forgejo, updates linked comments, and leaves removed comments alone", async () => {
+  it("pushes local notes to forgejo, updates linked comments, and prunes stale links for removed local notes", async () => {
     const issueClient = createInMemoryForgejoIssueClient();
     const itemLinkStore = createInMemoryForgejoItemLinkStore();
     const commentLinkStore = createInMemoryForgejoCommentLinkStore();
@@ -372,7 +372,7 @@ describe("forgejo comments", () => {
     expect(commentLinkStore.getByNoteId(binding.id, createNoteId("note-existing"))).toMatchObject({
       lastMirroredBody: "Updated local body",
     });
-    expect(commentLinkStore.getByNoteId(binding.id, createNoteId("note-delete"))).not.toBeNull();
+    expect(commentLinkStore.getByNoteId(binding.id, createNoteId("note-delete"))).toBeNull();
     expect(issueClient.snapshotComments(target, 7).map((comment) => comment.id)).toEqual([
       21, 22, 23,
     ]);
@@ -460,6 +460,87 @@ describe("forgejo comments", () => {
     expect(commentLinkStore.getByNoteId(binding.id, createNoteId("external:21"))).toMatchObject({
       lastMirroredBody: "Edited imported body",
     });
+  });
+
+  it("removes stale comment links for missing local notes before pushing", async () => {
+    const issueClient = createInMemoryForgejoIssueClient();
+    const itemLinkStore = createInMemoryForgejoItemLinkStore();
+    const commentLinkStore = createInMemoryForgejoCommentLinkStore();
+
+    issueClient.seedIssues(target, [
+      {
+        number: 7,
+        externalId: "https://forgejo.caradoc.com/erik/todu-forgejo-plugin-test#7",
+        title: "Issue",
+        state: "open",
+        labels: [],
+        assigneeActorIds: [],
+        assignees: [],
+        createdAt: "2026-03-12T00:00:00.000Z",
+        updatedAt: "2026-03-12T00:00:00.000Z",
+      },
+    ]);
+
+    itemLinkStore.save(
+      createLinkFromTask({
+        binding,
+        taskId: createTaskId("task-1"),
+        baseUrl: target.baseUrl,
+        owner: target.owner,
+        repo: target.repo,
+        issueNumber: 7,
+      })
+    );
+    commentLinkStore.save({
+      bindingId: binding.id,
+      taskId: createTaskId("task-1"),
+      noteId: createNoteId("note-stale"),
+      issueNumber: 7,
+      forgejoCommentId: 21,
+      lastMirroredAt: "2026-03-12T01:00:00.000Z",
+      lastMirroredBody: "Old local body",
+    });
+    commentLinkStore.save({
+      bindingId: binding.id,
+      taskId: createTaskId("task-1"),
+      noteId: createNoteId("note-existing"),
+      issueNumber: 7,
+      forgejoCommentId: 22,
+      lastMirroredAt: "2026-03-12T01:00:00.000Z",
+      lastMirroredBody: "Existing body",
+    });
+
+    const staleLinks: ForgejoCommentLink[] = [];
+    const result = await pushComments({
+      binding,
+      issueClient,
+      target,
+      tasks: [
+        createTask([
+          {
+            id: createNoteId("note-existing"),
+            content: "Existing body",
+            author: "bob",
+            tags: [],
+            createdAt: "2026-03-12T01:00:00.000Z",
+          },
+        ]),
+      ],
+      itemLinkStore,
+      commentLinkStore,
+      onStaleLink: ({ commentLink }) => {
+        staleLinks.push(commentLink);
+      },
+    });
+
+    expect(result.createdComments).toHaveLength(0);
+    expect(result.updatedComments).toHaveLength(0);
+    expect(result.commentLinks).toHaveLength(1);
+    expect(staleLinks).toEqual([
+      expect.objectContaining({ noteId: createNoteId("note-stale"), forgejoCommentId: 21 }),
+    ]);
+    expect(commentLinkStore.getByNoteId(binding.id, createNoteId("note-stale"))).toBeNull();
+    expect(commentLinkStore.getByNoteId(binding.id, createNoteId("note-existing"))).not.toBeNull();
   });
 
   it("skips unchanged linked notes and ignores unlinked imported notes", async () => {

--- a/src/forgejo-comments.ts
+++ b/src/forgejo-comments.ts
@@ -190,6 +190,11 @@ export interface PushCommentsResult {
   updatedComments: ForgejoComment[];
 }
 
+export interface PushCommentsStaleLinkContext {
+  itemLink: ForgejoItemLink;
+  commentLink: ForgejoCommentLink;
+}
+
 export async function pushComments(input: {
   binding: IntegrationBinding;
   issueClient: ForgejoIssueClient;
@@ -202,6 +207,7 @@ export async function pushComments(input: {
   tasks: ForgejoPushTask[];
   itemLinkStore: ForgejoItemLinkStore;
   commentLinkStore: ForgejoCommentLinkStore;
+  onStaleLink?: (context: PushCommentsStaleLinkContext) => void | Promise<void>;
 }): Promise<PushCommentsResult> {
   const commentLinks: SyncProviderPushCommentLink[] = [];
   const createdComments: ForgejoComment[] = [];
@@ -212,6 +218,25 @@ export async function pushComments(input: {
     const itemLink = input.itemLinkStore.getByTaskId(input.binding.id, localTaskId as never);
     if (!itemLink) {
       continue;
+    }
+
+    const currentNoteIds = new Set(
+      (task.comments as ForgejoPushComment[]).map((comment) => String(toPushNote(comment).id))
+    );
+
+    for (const existingCommentLink of input.commentLinkStore.listByTask(
+      input.binding.id,
+      itemLink.taskId
+    )) {
+      if (currentNoteIds.has(String(existingCommentLink.noteId))) {
+        continue;
+      }
+
+      input.commentLinkStore.remove(input.binding.id, existingCommentLink.noteId);
+      await input.onStaleLink?.({
+        itemLink,
+        commentLink: existingCommentLink,
+      });
     }
 
     for (const comment of task.comments as ForgejoPushComment[]) {

--- a/src/forgejo-provider-hardening.test.ts
+++ b/src/forgejo-provider-hardening.test.ts
@@ -258,6 +258,77 @@ describe("provider error classification coverage", () => {
     );
   });
 
+  it("removes stale push comment links for missing local notes and logs a warning", async () => {
+    const issueClient = createInMemoryForgejoIssueClient();
+    issueClient.seedIssues(target, [
+      {
+        number: 7,
+        externalId: "https://code.example.com/acme/roadmap#7",
+        title: "Issue seven",
+        state: "open",
+        labels: ["status:active"],
+        assignees: [],
+        createdAt: "2026-03-12T00:00:00.000Z",
+        updatedAt: "2026-03-12T01:00:00.000Z",
+      },
+    ]);
+
+    const linkStore = createInMemoryForgejoItemLinkStore();
+    linkStore.save({
+      bindingId: createBinding().id,
+      taskId: createTaskId("task-1"),
+      issueNumber: 7,
+      externalId: "https://code.example.com/acme/roadmap#7",
+      lastMirroredAt: "2026-03-12T01:00:00.000Z",
+    });
+
+    const commentLinkStore = createInMemoryForgejoCommentLinkStore();
+    commentLinkStore.save({
+      bindingId: createBinding().id,
+      taskId: createTaskId("task-1"),
+      noteId: createNoteId("note-stale"),
+      issueNumber: 7,
+      forgejoCommentId: 21,
+      lastMirroredAt: "2026-03-12T01:00:00.000Z",
+      lastMirroredBody: "Old local body",
+    });
+
+    const logger = createForgejoSyncLogger();
+    const provider = await initProvider({
+      issueClient,
+      linkStore,
+      commentLinkStore,
+      logger,
+    });
+
+    const pushResult = await provider.push(
+      createBinding(),
+      [
+        createPushTask({
+          id: createTaskId("task-1"),
+          externalId: "https://code.example.com/acme/roadmap#7",
+          comments: [],
+        }),
+      ],
+      project
+    );
+
+    expect(pushResult.commentLinks).toEqual([]);
+    expect(commentLinkStore.getByNoteId(createBinding().id, createNoteId("note-stale"))).toBeNull();
+    expect(logger.getEntries()).toContainEqual(
+      expect.objectContaining({
+        level: "warn",
+        message: "removing stale comment link for missing local note",
+        context: expect.objectContaining({
+          bindingId: createBinding().id,
+          direction: "push",
+          entityType: "comment",
+          itemId: "7:21",
+        }),
+      })
+    );
+  });
+
   it("keeps transient comment pull timeouts retryable", async () => {
     const issueClient = createInMemoryForgejoIssueClient();
     issueClient.seedIssues(target, [

--- a/src/forgejo-provider.ts
+++ b/src/forgejo-provider.ts
@@ -438,6 +438,13 @@ export function createForgejoSyncProvider(
           tasks: tasks as ExportedTaskInput[],
           itemLinkStore: linkStore,
           commentLinkStore,
+          onStaleLink: ({ itemLink, commentLink }) => {
+            logger.warn("removing stale comment link for missing local note", {
+              ...logContext,
+              entityType: "comment",
+              itemId: `${itemLink.issueNumber}:${commentLink.forgejoCommentId}`,
+            });
+          },
         });
 
         for (const createdComment of pushCommentsResult.createdComments) {


### PR DESCRIPTION
## Summary\n- prune stale Forgejo comment links when the local note is no longer present on the task\n- log a warning and continue sync instead of failing the full push cycle\n- add regression coverage for stale-link cleanup and provider warning behavior\n\n## Testing\n- npm run format\n- npm run lint\n- npm run typecheck\n- npm test\n- ./scripts/pre-pr.sh