### PR TITLE
fix: self-heal stale Forgejo comment links

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -11,6 +11,15 @@ export default tseslint.config(
     },
   },
   {
+    files: ["scripts/**/*.mjs"],
+    languageOptions: {
+      globals: {
+        console: "readonly",
+        process: "readonly",
+      },
+    },
+  },
+  {
     ignores: ["dist/", "node_modules/", "coverage/"],
   }
 );

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:watch": "vitest",
     "test:integration": "vitest run --config vitest.integration.config.ts",
     "test:coverage": "vitest run --coverage",
+    "repair:forgejo-comment-links": "node ./scripts/reconcile-forgejo-comment-links.mjs",
     "check": "npm run lint && npm test",
     "pre-pr": "./scripts/pre-pr.sh"
   },

--- a/scripts/reconcile-forgejo-comment-links.mjs
+++ b/scripts/reconcile-forgejo-comment-links.mjs
@@ -1,0 +1,309 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+const SYNC_EXTERNAL_ID_TAG_PREFIX = "sync:externalId:";
+const LEGACY_NOTE_ID_PREFIX = "external:";
+
+function parseArgs(argv) {
+  const args = {
+    storageDir: path.join(os.homedir(), ".config", "todu", "data", "forgejo-plugin-state"),
+    toduBin: "todu",
+    write: false,
+    bindingId: null,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === "--write") {
+      args.write = true;
+      continue;
+    }
+
+    if (arg === "--storage-dir") {
+      args.storageDir = requireValue(argv, ++index, arg);
+      continue;
+    }
+
+    if (arg === "--todu-bin") {
+      args.toduBin = requireValue(argv, ++index, arg);
+      continue;
+    }
+
+    if (arg === "--binding") {
+      args.bindingId = requireValue(argv, ++index, arg);
+      continue;
+    }
+
+    if (arg === "-h" || arg === "--help") {
+      printHelp();
+      process.exit(0);
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return args;
+}
+
+function requireValue(argv, index, flag) {
+  const value = argv[index];
+  if (!value) {
+    throw new Error(`Missing value for ${flag}`);
+  }
+
+  return value;
+}
+
+function printHelp() {
+  console.log(`Usage: node scripts/reconcile-forgejo-comment-links.mjs [options]
+
+Dry-run by default. Rewrites legacy Forgejo comment link note IDs like external:2592
+into real local note IDs by matching task notes with sync:externalId:<commentId> tags.
+
+Options:
+  --write                 persist the repaired comment-links.json
+  --storage-dir <path>    forgejo plugin storage dir
+  --todu-bin <path>       todu CLI binary to use (default: todu)
+  --binding <id>          limit reconciliation to one binding id
+  -h, --help              show help
+`);
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function writeJson(filePath, value) {
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function runToduJson(toduBin, args) {
+  const result = spawnSync(toduBin, ["--format", "json", ...args], {
+    encoding: "utf8",
+  });
+
+  if (result.status !== 0) {
+    throw new Error(
+      `Command failed: ${[toduBin, "--format", "json", ...args].join(" ")}\n${result.stderr || result.stdout}`
+    );
+  }
+
+  return JSON.parse(result.stdout || "null");
+}
+
+function getTaskNotesCached(cache, toduBin, taskId) {
+  if (!cache.has(taskId)) {
+    const notes = runToduJson(toduBin, ["note", "list", "--task", taskId]);
+    cache.set(taskId, Array.isArray(notes) ? notes : []);
+  }
+
+  return cache.get(taskId);
+}
+
+function getSyncExternalId(note) {
+  const tags = Array.isArray(note?.tags) ? note.tags : [];
+  const syncTag = tags.find(
+    (tag) => typeof tag === "string" && tag.startsWith(SYNC_EXTERNAL_ID_TAG_PREFIX)
+  );
+  return syncTag ? syncTag.slice(SYNC_EXTERNAL_ID_TAG_PREFIX.length) : null;
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const commentLinksPath = path.join(options.storageDir, "comment-links.json");
+  const itemLinksPath = path.join(options.storageDir, "item-links.json");
+
+  const commentLinks = readJson(commentLinksPath);
+  const itemLinks = readJson(itemLinksPath);
+  const itemLinksByIssue = new Map(
+    itemLinks.map((link) => [`${link.bindingId}:${link.issueNumber}`, link])
+  );
+  const notesCache = new Map();
+
+  const stats = {
+    total: 0,
+    targeted: 0,
+    updated: 0,
+    noteIdUpdated: 0,
+    taskIdUpdated: 0,
+    forgejoCommentIdUpdated: 0,
+    unresolved: 0,
+    ambiguous: 0,
+    missingItemLink: 0,
+  };
+
+  const repairs = [];
+  const unresolved = [];
+  const ambiguous = [];
+  const nextCommentLinks = commentLinks.map((link) => {
+    stats.total += 1;
+
+    if (options.bindingId && link.bindingId !== options.bindingId) {
+      return link;
+    }
+
+    const issueKey = `${link.bindingId}:${link.issueNumber}`;
+    const itemLink = itemLinksByIssue.get(issueKey);
+    const canonicalTaskId = itemLink?.taskId ?? link.taskId;
+    const legacyNoteId =
+      typeof link.noteId === "string" && link.noteId.startsWith(LEGACY_NOTE_ID_PREFIX);
+    const staleTaskId = canonicalTaskId !== link.taskId;
+
+    const notes = getTaskNotesCached(notesCache, options.toduBin, canonicalTaskId);
+    const currentNote = notes.find((note) => note.id === link.noteId);
+    const taggedExternalId = getSyncExternalId(currentNote);
+    const staleForgejoCommentId =
+      taggedExternalId !== null && taggedExternalId !== String(link.forgejoCommentId);
+
+    if (!legacyNoteId && !staleTaskId && !staleForgejoCommentId) {
+      return link;
+    }
+
+    stats.targeted += 1;
+
+    if (!itemLink) {
+      stats.missingItemLink += 1;
+      unresolved.push({
+        bindingId: link.bindingId,
+        issueNumber: link.issueNumber,
+        forgejoCommentId: link.forgejoCommentId,
+        reason: "missing item link",
+      });
+      return link;
+    }
+
+    let nextLink = link;
+
+    if (legacyNoteId) {
+      const matches = notes.filter(
+        (note) => getSyncExternalId(note) === String(link.forgejoCommentId)
+      );
+
+      if (matches.length === 0) {
+        stats.unresolved += 1;
+        unresolved.push({
+          bindingId: link.bindingId,
+          issueNumber: link.issueNumber,
+          forgejoCommentId: link.forgejoCommentId,
+          taskId: canonicalTaskId,
+          reason: "no matching local note with sync tag",
+        });
+        return link;
+      }
+
+      if (matches.length > 1) {
+        stats.ambiguous += 1;
+        ambiguous.push({
+          bindingId: link.bindingId,
+          issueNumber: link.issueNumber,
+          forgejoCommentId: link.forgejoCommentId,
+          taskId: canonicalTaskId,
+          noteIds: matches.map((note) => note.id),
+        });
+        return link;
+      }
+
+      nextLink = {
+        ...nextLink,
+        noteId: matches[0].id,
+      };
+      stats.noteIdUpdated += 1;
+    }
+
+    if (nextLink.taskId !== canonicalTaskId) {
+      nextLink = {
+        ...nextLink,
+        taskId: canonicalTaskId,
+      };
+      stats.taskIdUpdated += 1;
+    }
+
+    if (taggedExternalId !== null && nextLink.forgejoCommentId !== Number(taggedExternalId)) {
+      nextLink = {
+        ...nextLink,
+        forgejoCommentId: Number(taggedExternalId),
+      };
+      stats.forgejoCommentIdUpdated += 1;
+    }
+
+    if (nextLink !== link) {
+      stats.updated += 1;
+      repairs.push({
+        bindingId: link.bindingId,
+        issueNumber: link.issueNumber,
+        forgejoCommentId: link.forgejoCommentId,
+        fromTaskId: link.taskId,
+        toTaskId: nextLink.taskId,
+        fromNoteId: link.noteId,
+        toNoteId: nextLink.noteId,
+        fromForgejoCommentId: link.forgejoCommentId,
+        toForgejoCommentId: nextLink.forgejoCommentId,
+      });
+    }
+
+    return nextLink;
+  });
+
+  console.log(`Storage dir: ${options.storageDir}`);
+  console.log(`Mode: ${options.write ? "write" : "dry-run"}`);
+  if (options.bindingId) {
+    console.log(`Binding filter: ${options.bindingId}`);
+  }
+  console.log("");
+  console.log(`Total comment links: ${stats.total}`);
+  console.log(`Targeted legacy/stale links: ${stats.targeted}`);
+  console.log(`Repairs: ${stats.updated}`);
+  console.log(`- noteId updates: ${stats.noteIdUpdated}`);
+  console.log(`- taskId updates: ${stats.taskIdUpdated}`);
+  console.log(`- forgejoCommentId updates: ${stats.forgejoCommentIdUpdated}`);
+  console.log(`Unresolved: ${stats.unresolved}`);
+  console.log(`Ambiguous: ${stats.ambiguous}`);
+  console.log(`Missing item links: ${stats.missingItemLink}`);
+
+  if (repairs.length > 0) {
+    console.log("\nRepairs:");
+    for (const repair of repairs) {
+      console.log(
+        `- ${repair.bindingId} issue #${repair.issueNumber} comment ${repair.forgejoCommentId}: task ${repair.fromTaskId} -> ${repair.toTaskId}; note ${repair.fromNoteId} -> ${repair.toNoteId}` +
+          (repair.fromForgejoCommentId && repair.fromForgejoCommentId !== repair.toForgejoCommentId
+            ? `; forgejoComment ${repair.fromForgejoCommentId} -> ${repair.toForgejoCommentId}`
+            : "")
+      );
+    }
+  }
+
+  if (unresolved.length > 0) {
+    console.log("\nUnresolved:");
+    for (const item of unresolved) {
+      console.log(
+        `- ${item.bindingId} issue #${item.issueNumber} comment ${item.forgejoCommentId}: ${item.reason}${item.taskId ? ` (task ${item.taskId})` : ""}`
+      );
+    }
+  }
+
+  if (ambiguous.length > 0) {
+    console.log("\nAmbiguous:");
+    for (const item of ambiguous) {
+      console.log(
+        `- ${item.bindingId} issue #${item.issueNumber} comment ${item.forgejoCommentId}: matches ${item.noteIds.join(", ")}`
+      );
+    }
+  }
+
+  if (options.write && repairs.length > 0) {
+    writeJson(commentLinksPath, nextCommentLinks);
+    console.log(`\nWrote updated links to ${commentLinksPath}`);
+  }
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}

--- a/src/forgejo-comments.test.ts
+++ b/src/forgejo-comments.test.ts
@@ -3,6 +3,7 @@ import {
   createNoteId,
   createProjectId,
   createTaskId,
+  type ExportedTaskInput,
   type IntegrationBinding,
   type TaskPushPayload,
 } from "@todu/core";
@@ -377,6 +378,19 @@ describe("forgejo comments", () => {
       21, 22, 23,
     ]);
     expect(result.commentLinks).toHaveLength(2);
+    expect(result.commentLinks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          localNoteId: createNoteId("note-existing"),
+          externalTaskId: createTaskId("task-1"),
+          externalCommentId: "21",
+        }),
+        expect.objectContaining({
+          localNoteId: createNoteId("note-new"),
+          externalTaskId: createTaskId("task-1"),
+        }),
+      ])
+    );
   });
 
   it("pushes edits made to imported forgejo notes back to forgejo when the local note changed", async () => {
@@ -541,6 +555,160 @@ describe("forgejo comments", () => {
     ]);
     expect(commentLinkStore.getByNoteId(binding.id, createNoteId("note-stale"))).toBeNull();
     expect(commentLinkStore.getByNoteId(binding.id, createNoteId("note-existing"))).not.toBeNull();
+  });
+
+  it("reconciles note-tag comment linkage conflicts to the canonical forgejo comment id during push", async () => {
+    const issueClient = createInMemoryForgejoIssueClient();
+    const itemLinkStore = createInMemoryForgejoItemLinkStore();
+    const commentLinkStore = createInMemoryForgejoCommentLinkStore();
+
+    issueClient.seedIssues(target, [
+      {
+        number: 7,
+        externalId: "https://forgejo.caradoc.com/erik/todu-forgejo-plugin-test#7",
+        title: "Issue",
+        state: "open",
+        labels: [],
+        assigneeActorIds: [],
+        assignees: [],
+        createdAt: "2026-03-12T00:00:00.000Z",
+        updatedAt: "2026-03-12T00:00:00.000Z",
+      },
+    ]);
+
+    itemLinkStore.save(
+      createLinkFromTask({
+        binding,
+        taskId: createTaskId("task-1"),
+        baseUrl: target.baseUrl,
+        owner: target.owner,
+        repo: target.repo,
+        issueNumber: 7,
+      })
+    );
+    commentLinkStore.save({
+      bindingId: binding.id,
+      taskId: createTaskId("task-1"),
+      noteId: createNoteId("note-real"),
+      issueNumber: 7,
+      forgejoCommentId: 99,
+      lastMirroredAt: "2026-03-12T05:00:00.000Z",
+      lastMirroredBody: "Remote changed body",
+    });
+
+    const result = await pushComments({
+      binding,
+      issueClient,
+      target,
+      tasks: [
+        createTask([
+          {
+            id: createNoteId("note-real"),
+            content: "Remote changed body",
+            author: "bob",
+            tags: ["sync:externalId:21"],
+            createdAt: "2026-03-12T00:00:00.000Z",
+          },
+        ]),
+      ],
+      itemLinkStore,
+      commentLinkStore,
+    });
+
+    expect(result.commentLinks).toEqual([
+      expect.objectContaining({
+        localNoteId: createNoteId("note-real"),
+        externalTaskId: createTaskId("task-1"),
+        externalCommentId: "21",
+      }),
+    ]);
+    expect(commentLinkStore.getByNoteId(binding.id, createNoteId("note-real"))).toMatchObject({
+      forgejoCommentId: 21,
+      lastMirroredBody: "Remote changed body",
+    });
+  });
+
+  it("reconciles legacy imported comment links to real local note ids during push", async () => {
+    const issueClient = createInMemoryForgejoIssueClient();
+    const itemLinkStore = createInMemoryForgejoItemLinkStore();
+    const commentLinkStore = createInMemoryForgejoCommentLinkStore();
+
+    issueClient.seedIssues(target, [
+      {
+        number: 7,
+        externalId: "https://forgejo.caradoc.com/erik/todu-forgejo-plugin-test#7",
+        title: "Issue",
+        state: "open",
+        labels: [],
+        assigneeActorIds: [],
+        assignees: [],
+        createdAt: "2026-03-12T00:00:00.000Z",
+        updatedAt: "2026-03-12T00:00:00.000Z",
+      },
+    ]);
+
+    itemLinkStore.save(
+      createLinkFromTask({
+        binding,
+        taskId: createTaskId("task-1"),
+        baseUrl: target.baseUrl,
+        owner: target.owner,
+        repo: target.repo,
+        issueNumber: 7,
+      })
+    );
+    commentLinkStore.save({
+      bindingId: binding.id,
+      taskId: createTaskId("task-legacy"),
+      noteId: createNoteId("external:21"),
+      issueNumber: 7,
+      forgejoCommentId: 21,
+      lastMirroredAt: "2026-03-12T05:00:00.000Z",
+      lastMirroredBody: "Remote changed body",
+    });
+
+    const task: ExportedTaskInput = {
+      localTaskId: createTaskId("task-1"),
+      externalId: "https://forgejo.caradoc.com/erik/todu-forgejo-plugin-test#7",
+      title: "Sync comments",
+      description: "Test task",
+      status: "active",
+      priority: "medium",
+      labels: [],
+      assignees: [],
+      updatedAt: "2026-03-12T04:00:00.000Z",
+      comments: [
+        {
+          localNoteId: createNoteId("note-real"),
+          body: formatAttributedBody(
+            formatForgejoAttribution("alice", "2026-03-12T00:00:00.000Z"),
+            "Remote changed body"
+          ),
+          createdAt: "2026-03-12T00:00:00.000Z",
+        },
+      ],
+    };
+
+    const result = await pushComments({
+      binding,
+      issueClient,
+      target,
+      tasks: [task],
+      itemLinkStore,
+      commentLinkStore,
+    });
+
+    expect(result.updatedComments).toHaveLength(0);
+    expect(result.createdComments).toHaveLength(0);
+    expect(result.commentLinks).toEqual([
+      expect.objectContaining({ localNoteId: createNoteId("note-real"), externalCommentId: "21" }),
+    ]);
+    expect(commentLinkStore.getByNoteId(binding.id, createNoteId("note-real"))).toMatchObject({
+      taskId: createTaskId("task-1"),
+      forgejoCommentId: 21,
+      lastMirroredBody: "Remote changed body",
+    });
+    expect(commentLinkStore.getByNoteId(binding.id, createNoteId("external:21"))).toBeNull();
   });
 
   it("skips unchanged linked notes and ignores unlinked imported notes", async () => {

--- a/src/forgejo-comments.ts
+++ b/src/forgejo-comments.ts
@@ -81,6 +81,15 @@ function hasImportedForgejoSyncTag(note: Pick<Note, "tags">): boolean {
   return note.tags.some((tag) => tag.startsWith(SYNC_EXTERNAL_ID_TAG_PREFIX));
 }
 
+function isLegacyImportedCommentLinkNoteId(noteId: NoteId): boolean {
+  return String(noteId).startsWith(IMPORTED_COMMENT_LINK_PREFIX);
+}
+
+function getImportedForgejoSyncExternalId(note: Pick<Note, "tags">): string | null {
+  const syncTag = note.tags.find((tag) => tag.startsWith(SYNC_EXTERNAL_ID_TAG_PREFIX));
+  return syncTag ? syncTag.slice(SYNC_EXTERNAL_ID_TAG_PREFIX.length) : null;
+}
+
 export interface PullCommentsResult {
   comments: ImportedCommentInput[];
   createdLinks: ForgejoCommentLink[];
@@ -220,13 +229,14 @@ export async function pushComments(input: {
       continue;
     }
 
-    const currentNoteIds = new Set(
-      (task.comments as ForgejoPushComment[]).map((comment) => String(toPushNote(comment).id))
-    );
+    const notes = (task.comments as ForgejoPushComment[]).map((comment) => toPushNote(comment));
+    reconcileLegacyCommentLinks(input.binding.id, itemLink, notes, input.commentLinkStore);
 
-    for (const existingCommentLink of input.commentLinkStore.listByTask(
+    const currentNoteIds = new Set(notes.map((note) => String(note.id)));
+
+    for (const existingCommentLink of input.commentLinkStore.listByIssue(
       input.binding.id,
-      itemLink.taskId
+      itemLink.issueNumber
     )) {
       if (currentNoteIds.has(String(existingCommentLink.noteId))) {
         continue;
@@ -239,8 +249,7 @@ export async function pushComments(input: {
       });
     }
 
-    for (const comment of task.comments as ForgejoPushComment[]) {
-      const note = toPushNote(comment);
+    for (const note of notes) {
       const existingLink = input.commentLinkStore.getByNoteId(input.binding.id, note.id);
 
       if (
@@ -258,16 +267,11 @@ export async function pushComments(input: {
           updatedComments
         );
         commentLinks.push(
-          createPushCommentLink(
-            note.id,
-            itemLink.externalId,
-            existingLink.forgejoCommentId,
-            updated
-          )
+          createPushCommentLink(note.id, itemLink.taskId, existingLink.forgejoCommentId, updated)
         );
       } else {
         const created = await createForgejoCommentFromNote(input, note, itemLink, createdComments);
-        commentLinks.push(createPushCommentLink(note.id, itemLink.externalId, created.id, created));
+        commentLinks.push(createPushCommentLink(note.id, itemLink.taskId, created.id, created));
       }
     }
   }
@@ -299,6 +303,78 @@ function toPushNote(
     author: comment.author,
     createdAt: comment.createdAt,
   };
+}
+
+function reconcileLegacyCommentLinks(
+  bindingId: IntegrationBinding["id"],
+  itemLink: ForgejoItemLink,
+  notes: Array<Pick<Note, "id" | "content" | "tags">>,
+  commentLinkStore: ForgejoCommentLinkStore
+): void {
+  for (const existingLink of commentLinkStore.listByIssue(bindingId, itemLink.issueNumber)) {
+    const noteWithMatchingSyncTag = notes.find(
+      (note) => getImportedForgejoSyncExternalId(note) === String(existingLink.forgejoCommentId)
+    );
+    const noteWithSameId = notes.find((note) => note.id === existingLink.noteId);
+    const taggedForgejoCommentId = noteWithSameId
+      ? getImportedForgejoSyncExternalId(noteWithSameId)
+      : null;
+    const resolvedNoteId = isLegacyImportedCommentLinkNoteId(existingLink.noteId)
+      ? resolveLegacyCommentLinkNoteId(existingLink, notes)
+      : existingLink.noteId;
+    const resolvedForgejoCommentId = taggedForgejoCommentId
+      ? Number(taggedForgejoCommentId)
+      : existingLink.forgejoCommentId;
+
+    if (resolvedNoteId === null) {
+      continue;
+    }
+
+    const nextNoteId = noteWithMatchingSyncTag?.id ?? resolvedNoteId;
+
+    if (
+      existingLink.taskId === itemLink.taskId &&
+      existingLink.noteId === nextNoteId &&
+      existingLink.forgejoCommentId === resolvedForgejoCommentId
+    ) {
+      continue;
+    }
+
+    commentLinkStore.save({
+      ...existingLink,
+      taskId: itemLink.taskId,
+      noteId: nextNoteId,
+      forgejoCommentId: resolvedForgejoCommentId,
+    });
+  }
+}
+
+function resolveLegacyCommentLinkNoteId(
+  existingLink: ForgejoCommentLink,
+  notes: Array<Pick<Note, "id" | "content" | "tags">>
+): NoteId | null {
+  const matchingNotes = notes.filter((note) => {
+    const importedExternalId = getImportedForgejoSyncExternalId(note);
+    if (importedExternalId === String(existingLink.forgejoCommentId)) {
+      return true;
+    }
+
+    if (!hasForgejoAttribution(note.content)) {
+      return false;
+    }
+
+    if (existingLink.lastMirroredBody === undefined) {
+      return false;
+    }
+
+    return stripAttribution(note.content) === existingLink.lastMirroredBody;
+  });
+
+  if (matchingNotes.length !== 1) {
+    return null;
+  }
+
+  return matchingNotes[0].id;
 }
 
 async function updateForgejoCommentIfNeeded(
@@ -400,14 +476,14 @@ async function createForgejoCommentFromNote(
 
 function createPushCommentLink(
   noteId: NoteId,
-  externalTaskId: string,
+  taskId: ForgejoItemLink["taskId"],
   forgejoCommentId: number,
   comment: ForgejoComment | null
 ): SyncProviderPushCommentLink {
   return {
     localNoteId: noteId,
     externalCommentId: String(forgejoCommentId),
-    externalTaskId,
+    externalTaskId: String(taskId),
     sourceUrl: comment?.sourceUrl,
     createdAt: comment?.createdAt,
     updatedAt: comment?.updatedAt,

--- a/src/forgejo-provider-hardening.test.ts
+++ b/src/forgejo-provider-hardening.test.ts
@@ -329,6 +329,91 @@ describe("provider error classification coverage", () => {
     );
   });
 
+  it("reconciles legacy imported comment links to real local note ids before returning push links", async () => {
+    const issueClient = createInMemoryForgejoIssueClient();
+    issueClient.seedIssues(target, [
+      {
+        number: 7,
+        externalId: "https://code.example.com/acme/roadmap#7",
+        title: "Issue seven",
+        state: "open",
+        labels: ["status:active"],
+        assignees: [],
+        createdAt: "2026-03-12T00:00:00.000Z",
+        updatedAt: "2026-03-12T01:00:00.000Z",
+      },
+    ]);
+
+    const linkStore = createInMemoryForgejoItemLinkStore();
+    linkStore.save({
+      bindingId: createBinding().id,
+      taskId: createTaskId("task-1"),
+      issueNumber: 7,
+      externalId: "https://code.example.com/acme/roadmap#7",
+      lastMirroredAt: "2026-03-12T01:00:00.000Z",
+    });
+
+    const commentLinkStore = createInMemoryForgejoCommentLinkStore();
+    commentLinkStore.save({
+      bindingId: createBinding().id,
+      taskId: createTaskId("task-legacy"),
+      noteId: createNoteId("external:21"),
+      issueNumber: 7,
+      forgejoCommentId: 21,
+      lastMirroredAt: "2026-03-12T01:00:00.000Z",
+      lastMirroredBody: "Imported body",
+    });
+
+    const provider = await initProvider({
+      issueClient,
+      linkStore,
+      commentLinkStore,
+    });
+
+    const pushResult = await provider.push(
+      createBinding(),
+      [
+        {
+          localTaskId: createTaskId("task-1"),
+          externalId: "https://code.example.com/acme/roadmap#7",
+          title: "Task one",
+          description: "",
+          status: "active",
+          priority: "medium",
+          labels: [],
+          assignees: [],
+          updatedAt: "2026-03-12T03:00:00.000Z",
+          comments: [
+            {
+              localNoteId: createNoteId("note-real"),
+              body: "_Synced from Forgejo comment by @alice on 2026-03-12T00:00:00.000Z_\n\nImported body",
+              createdAt: "2026-03-12T00:00:00.000Z",
+            },
+          ],
+        },
+      ],
+      project
+    );
+
+    expect(pushResult.commentLinks).toEqual([
+      expect.objectContaining({
+        localNoteId: createNoteId("note-real"),
+        externalCommentId: "21",
+        externalTaskId: createTaskId("task-1"),
+      }),
+    ]);
+    expect(
+      commentLinkStore.getByNoteId(createBinding().id, createNoteId("note-real"))
+    ).toMatchObject({
+      taskId: createTaskId("task-1"),
+      forgejoCommentId: 21,
+      lastMirroredBody: "Imported body",
+    });
+    expect(
+      commentLinkStore.getByNoteId(createBinding().id, createNoteId("external:21"))
+    ).toBeNull();
+  });
+
   it("keeps transient comment pull timeouts retryable", async () => {
     const issueClient = createInMemoryForgejoIssueClient();
     issueClient.seedIssues(target, [


### PR DESCRIPTION
## Summary
- self-heal stale Forgejo comment-link mappings during push
- prefer canonical note `sync:externalId:*` linkage when local comment-link state disagrees
- add a repair script and tests for stale-link reconciliation paths

## Verification
- npm run format
- npm run lint
- npm run typecheck
- npm test

Task: #task-d427686f