### PR TITLE
Remove legacy push-task shims from Forgejo plugin

### DIFF
--- a/src/forgejo-bootstrap-hardening.test.ts
+++ b/src/forgejo-bootstrap-hardening.test.ts
@@ -2,8 +2,8 @@ import {
   createIntegrationBindingId,
   createProjectId,
   createTaskId,
+  type ExportedTaskInput,
   type IntegrationBinding,
-  type TaskPushPayload,
 } from "@todu/core";
 
 import { createInMemoryForgejoIssueClient } from "@/forgejo-client";
@@ -29,19 +29,16 @@ const target = {
   repo: "roadmap",
 };
 
-function createPushTask(overrides: Partial<TaskPushPayload> = {}): TaskPushPayload {
+function createPushTask(overrides: Partial<ExportedTaskInput> = {}): ExportedTaskInput {
   return {
-    id: createTaskId("task-1"),
+    localTaskId: createTaskId("task-1"),
     title: "Test task",
     description: "",
     status: "active",
     priority: "medium",
-    projectId: binding.projectId,
     labels: [],
-    assigneeActorIds: overrides.assigneeActorIds ?? [],
     assignees: [],
     comments: [],
-    createdAt: "2026-03-12T00:00:00.000Z",
     updatedAt: "2026-03-12T00:00:00.000Z",
     ...overrides,
   };
@@ -344,8 +341,8 @@ describe("bootstrap status transitions", () => {
       binding,
       ...target,
       tasks: [
-        createPushTask({ id: createTaskId("done-task"), status: "done" }),
-        createPushTask({ id: createTaskId("canceled-task"), status: "canceled" }),
+        createPushTask({ localTaskId: createTaskId("done-task"), status: "done" }),
+        createPushTask({ localTaskId: createTaskId("canceled-task"), status: "canceled" }),
       ],
       issueClient,
       linkStore,
@@ -415,7 +412,7 @@ describe("bootstrap status transitions", () => {
       ...target,
       tasks: [
         createPushTask({
-          id: createTaskId("task-equal"),
+          localTaskId: createTaskId("task-equal"),
           title: "Changed title but equal timestamp",
           externalId: "https://code.example.com/acme/roadmap#1",
           updatedAt: "2026-03-12T01:00:00.000Z",

--- a/src/forgejo-bootstrap.test.ts
+++ b/src/forgejo-bootstrap.test.ts
@@ -2,8 +2,8 @@ import {
   createIntegrationBindingId,
   createProjectId,
   createTaskId,
+  type ExportedTaskInput,
   type IntegrationBinding,
-  type TaskPushPayload,
 } from "@todu/core";
 
 import { createInMemoryForgejoIssueClient } from "@/forgejo-client";
@@ -29,6 +29,21 @@ const target = {
   owner: "erik",
   repo: "todu-forgejo-plugin-test",
 };
+
+function createExportedTask(overrides: Partial<ExportedTaskInput> = {}): ExportedTaskInput {
+  return {
+    localTaskId: createTaskId("task-1"),
+    title: "Test task",
+    description: "",
+    status: "active",
+    priority: "medium",
+    labels: [],
+    assignees: [],
+    updatedAt: "2026-03-12T00:00:00.000Z",
+    comments: [],
+    ...overrides,
+  };
+}
 
 describe("forgejo bootstrap", () => {
   it("imports open issues with normalized fields and creates durable links", async () => {
@@ -90,34 +105,21 @@ describe("forgejo bootstrap", () => {
   it("exports active tasks to forgejo with normalized fields, assignees, and creates missing labels", async () => {
     const issueClient = createInMemoryForgejoIssueClient();
     const linkStore = createInMemoryForgejoItemLinkStore();
-    const tasks: TaskPushPayload[] = [
-      {
-        id: createTaskId("task-1"),
+    const tasks: ExportedTaskInput[] = [
+      createExportedTask({
+        localTaskId: createTaskId("task-1"),
         title: "Create sync",
         description: "Bootstrap this issue",
         status: "active",
         priority: "high",
-        projectId: binding.projectId,
         labels: ["bug"],
-        assigneeActorIds: [],
-        assignees: ["caradoc"],
-        comments: [],
-        createdAt: "2026-03-12T00:00:00.000Z",
-        updatedAt: "2026-03-12T00:00:00.000Z",
-      },
-      {
-        id: createTaskId("task-2"),
+        assignees: [{ externalLogin: "caradoc", displayName: "caradoc" }],
+      }),
+      createExportedTask({
+        localTaskId: createTaskId("task-2"),
         title: "Ignore closed task",
         status: "done",
-        priority: "medium",
-        projectId: binding.projectId,
-        labels: [],
-        assigneeActorIds: [],
-        assignees: [],
-        comments: [],
-        createdAt: "2026-03-12T00:00:00.000Z",
-        updatedAt: "2026-03-12T00:00:00.000Z",
-      },
+      }),
     ];
 
     const result = await bootstrapTasksToForgejoIssues({
@@ -142,7 +144,7 @@ describe("forgejo bootstrap", () => {
     expect(result.createdLinks[0].lastMirroredAt).toBeDefined();
     expect(result.taskUpdates).toEqual([
       expect.objectContaining({
-        taskId: String(tasks[0].id),
+        taskId: String(tasks[0].localTaskId),
         externalId: expect.any(String),
         sourceUrl: "https://forgejo.caradoc.com/erik/todu-forgejo-plugin-test/issues/1",
       }),
@@ -167,21 +169,14 @@ describe("forgejo bootstrap", () => {
       },
     ]);
 
-    const tasks: TaskPushPayload[] = [
-      {
-        id: createTaskId("task-1"),
+    const tasks: ExportedTaskInput[] = [
+      createExportedTask({
+        localTaskId: createTaskId("task-1"),
         title: "Reuse issue",
         externalId: "https://forgejo.caradoc.com/erik/todu-forgejo-plugin-test#7",
-        status: "active",
-        priority: "medium",
-        projectId: binding.projectId,
         labels: ["needs-review"],
-        assigneeActorIds: [],
-        assignees: [],
-        comments: [],
-        createdAt: "2026-03-12T00:00:00.000Z",
         updatedAt: "2026-03-12T01:00:00.000Z",
-      },
+      }),
     ];
 
     const result = await bootstrapTasksToForgejoIssues({
@@ -204,7 +199,7 @@ describe("forgejo bootstrap", () => {
       "priority:medium",
     ]);
     expect(issueClient.snapshotLabels(target)).toContain("needs-review");
-    expect(linkStore.getByTaskId(binding.id, tasks[0].id)).toMatchObject({
+    expect(linkStore.getByTaskId(binding.id, tasks[0].localTaskId)).toMatchObject({
       issueNumber: 7,
       lastMirroredAt: expect.any(String),
     });
@@ -235,19 +230,12 @@ describe("forgejo bootstrap", () => {
       owner: target.owner,
       repo: target.repo,
       tasks: [
-        {
-          id: createTaskId("task-7"),
+        createExportedTask({
+          localTaskId: createTaskId("task-7"),
           title: "Unchanged title",
           description: "Unchanged body",
-          status: "active",
-          priority: "medium",
-          projectId: binding.projectId,
-          labels: [],
-          assignees: [],
-          comments: [],
-          createdAt: "2026-03-12T00:00:00.000Z",
           updatedAt: "2026-03-12T01:00:00.000Z",
-        },
+        }),
       ],
       issueClient,
       linkStore,
@@ -290,19 +278,12 @@ describe("forgejo bootstrap", () => {
       owner: target.owner,
       repo: target.repo,
       tasks: [
-        {
-          id: createTaskId("task-7"),
+        createExportedTask({
+          localTaskId: createTaskId("task-7"),
           title: "Older task",
           description: "Existing body",
-          status: "active",
-          priority: "medium",
-          projectId: binding.projectId,
-          labels: [],
-          assignees: [],
-          comments: [],
-          createdAt: "2026-03-12T00:00:00.000Z",
           updatedAt: "2026-03-12T01:00:00.000Z",
-        },
+        }),
       ],
       issueClient,
       linkStore,
@@ -349,20 +330,14 @@ describe("forgejo bootstrap", () => {
       owner: target.owner,
       repo: target.repo,
       tasks: [
-        {
-          id: createTaskId("task-remote-newer"),
+        createExportedTask({
+          localTaskId: createTaskId("task-remote-newer"),
           title: "test actors",
           description: undefined,
-          status: "active",
-          priority: "medium",
-          projectId: binding.projectId,
-          labels: [],
-          assignees: ["caradoc"],
-          comments: [],
-          createdAt: "2026-03-12T00:00:00.000Z",
+          assignees: [{ externalLogin: "caradoc", displayName: "caradoc" }],
           updatedAt: "2026-03-12T02:00:00.000Z",
           externalId: "https://forgejo.caradoc.com/erik/todu-forgejo-plugin-test#9",
-        },
+        }),
       ],
       issueClient,
       linkStore,
@@ -389,32 +364,21 @@ describe("forgejo bootstrap", () => {
       owner: target.owner,
       repo: target.repo,
       tasks: [
-        {
-          id: createTaskId("task-a"),
+        createExportedTask({
+          localTaskId: createTaskId("task-a"),
           title: "Task A",
           description: "A",
-          status: "active",
-          priority: "medium",
-          projectId: binding.projectId,
           labels: ["bug"],
-          assignees: [],
-          comments: [],
-          createdAt: "2026-03-12T00:00:00.000Z",
           updatedAt: "2026-03-12T01:00:00.000Z",
-        },
-        {
-          id: createTaskId("task-b"),
+        }),
+        createExportedTask({
+          localTaskId: createTaskId("task-b"),
           title: "Task B",
           description: "B",
-          status: "active",
           priority: "high",
-          projectId: binding.projectId,
           labels: ["feature"],
-          assignees: [],
-          comments: [],
-          createdAt: "2026-03-12T00:00:00.000Z",
           updatedAt: "2026-03-12T01:00:00.000Z",
-        },
+        }),
       ],
       issueClient,
       linkStore: createInMemoryForgejoItemLinkStore(),

--- a/src/forgejo-bootstrap.ts
+++ b/src/forgejo-bootstrap.ts
@@ -1,12 +1,4 @@
-import type {
-  ExportedTaskInput,
-  ImportedTaskInput,
-  IntegrationBinding,
-  Note,
-  TaskPushPayload,
-  TaskStatus,
-  TaskPriority,
-} from "@todu/core";
+import type { ExportedTaskInput, ImportedTaskInput, IntegrationBinding } from "@todu/core";
 
 import {
   createForgejoIssueCreateFromTask,
@@ -23,24 +15,7 @@ import {
   type ForgejoItemLinkStore,
 } from "@/forgejo-links";
 
-interface ForgejoLegacyPushTask {
-  id: string;
-  title: string;
-  description?: string;
-  status: TaskStatus;
-  priority: TaskPriority;
-  labels: string[];
-  assignees?: string[];
-  comments: Note[];
-  externalId?: string;
-  sourceUrl?: string;
-  createdAt?: string;
-  updatedAt?: string;
-}
-
-type ForgejoPushTask = ExportedTaskInput | TaskPushPayload | ForgejoLegacyPushTask;
-
-const TASK_BOOTSTRAP_EXPORT_STATUSES = new Set<ForgejoPushTask["status"]>([
+const TASK_BOOTSTRAP_EXPORT_STATUSES = new Set<ExportedTaskInput["status"]>([
   "active",
   "inprogress",
   "waiting",
@@ -53,7 +28,7 @@ export interface ForgejoBootstrapImportResult {
 }
 
 export interface ForgejoBootstrapTaskUpdate {
-  taskId: string;
+  taskId: ExportedTaskInput["localTaskId"];
   externalId: string;
   sourceUrl?: string;
 }
@@ -142,7 +117,7 @@ export async function bootstrapTasksToForgejoIssues(input: {
   apiBaseUrl: string;
   owner: string;
   repo: string;
-  tasks: ForgejoPushTask[];
+  tasks: ExportedTaskInput[];
   issueClient: ForgejoIssueClient;
   linkStore: ForgejoItemLinkStore;
   commentLinkStore?: ForgejoCommentLinkStore;
@@ -175,7 +150,7 @@ export async function bootstrapTasksToForgejoIssues(input: {
     }
   };
 
-  const clearStaleTaskReferences = (taskId: string): void => {
+  const clearStaleTaskReferences = (taskId: ExportedTaskInput["localTaskId"]): void => {
     input.linkStore.remove(input.binding.id, taskId as ForgejoItemLink["taskId"]);
 
     if (!input.commentLinkStore) {
@@ -190,7 +165,7 @@ export async function bootstrapTasksToForgejoIssues(input: {
     }
   };
 
-  const createIssueForTask = async (task: ForgejoPushTask): Promise<boolean> => {
+  const createIssueForTask = async (task: ExportedTaskInput): Promise<boolean> => {
     if (!TASK_BOOTSTRAP_EXPORT_STATUSES.has(task.status)) {
       return false;
     }
@@ -203,7 +178,7 @@ export async function bootstrapTasksToForgejoIssues(input: {
 
     const createdLink = createLinkFromTask({
       binding: input.binding,
-      taskId: getLocalTaskId(task) as ForgejoItemLink["taskId"],
+      taskId: task.localTaskId as ForgejoItemLink["taskId"],
       baseUrl: input.baseUrl,
       owner: input.owner,
       repo: input.repo,
@@ -213,7 +188,7 @@ export async function bootstrapTasksToForgejoIssues(input: {
     input.linkStore.save(createdLink);
     createdLinks.push(createdLink);
     taskUpdates.push({
-      taskId: getLocalTaskId(task),
+      taskId: task.localTaskId,
       externalId: createdLink.externalId,
       sourceUrl: createdIssue.sourceUrl,
     });
@@ -222,7 +197,7 @@ export async function bootstrapTasksToForgejoIssues(input: {
   };
 
   for (const task of input.tasks) {
-    const localTaskId = getLocalTaskId(task);
+    const localTaskId = task.localTaskId;
     const existingLink = input.linkStore.getByTaskId(
       input.binding.id,
       localTaskId as ForgejoItemLink["taskId"]
@@ -332,7 +307,7 @@ export async function bootstrapTasksToForgejoIssues(input: {
     await createIssueForTask(task);
   }
 
-  const currentTaskIds = new Set(input.tasks.map((task) => getLocalTaskId(task)));
+  const currentTaskIds = new Set(input.tasks.map((task) => String(task.localTaskId)));
   const orphanedLinks = input.linkStore
     .list(input.binding.id)
     .filter((link) => !currentTaskIds.has(String(link.taskId)));
@@ -378,10 +353,6 @@ export async function bootstrapTasksToForgejoIssues(input: {
   };
 }
 
-function getLocalTaskId(task: ForgejoPushTask): string {
-  return "localTaskId" in task ? String(task.localTaskId) : String(task.id);
-}
-
 function isForgejoIssueNotFoundError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
   return /\b404\b/.test(message) || /issue not found/i.test(message);
@@ -402,7 +373,7 @@ function createForgejoIssueCloseFromDeletion(issue: ForgejoIssue): {
   };
 }
 
-function shouldPushTaskUpdate(task: ForgejoPushTask, issue: ForgejoIssue | null): boolean {
+function shouldPushTaskUpdate(task: ExportedTaskInput, issue: ForgejoIssue | null): boolean {
   if (!issue) {
     return true;
   }
@@ -415,15 +386,14 @@ function shouldPushTaskUpdate(task: ForgejoPushTask, issue: ForgejoIssue | null)
 }
 
 function shouldPushTaskUpdateFromMirroredAt(
-  task: ForgejoPushTask,
+  task: ExportedTaskInput,
   lastMirroredAt: string | undefined
 ): boolean {
   if (!lastMirroredAt) {
     return true;
   }
 
-  const taskUpdatedAt =
-    "updatedAt" in task && typeof task.updatedAt === "string" ? task.updatedAt : undefined;
+  const taskUpdatedAt = task.updatedAt;
   if (!taskUpdatedAt) {
     return true;
   }
@@ -431,7 +401,7 @@ function shouldPushTaskUpdateFromMirroredAt(
   return taskUpdatedAt > lastMirroredAt;
 }
 
-function issueMatchesTask(task: ForgejoPushTask, issue: ForgejoIssue): boolean {
+function issueMatchesTask(task: ExportedTaskInput, issue: ForgejoIssue): boolean {
   const expected = createForgejoIssueCreateFromTask(task);
 
   if (expected.title !== issue.title) {
@@ -477,7 +447,7 @@ function issueMatchesTask(task: ForgejoPushTask, issue: ForgejoIssue): boolean {
 }
 
 function getMatchingExternalId(
-  task: ForgejoPushTask,
+  task: ExportedTaskInput,
   baseUrl: string,
   owner: string,
   repo: string

--- a/src/forgejo-comments.test.ts
+++ b/src/forgejo-comments.test.ts
@@ -3,9 +3,9 @@ import {
   createNoteId,
   createProjectId,
   createTaskId,
+  type ExportedCommentInput,
   type ExportedTaskInput,
   type IntegrationBinding,
-  type TaskPushPayload,
 } from "@todu/core";
 
 import {
@@ -44,21 +44,18 @@ const target = {
 };
 
 function createTask(
-  comments: TaskPushPayload["comments"],
+  comments: ExportedCommentInput[],
   updatedAt = "2026-03-12T00:00:00.000Z"
-): TaskPushPayload {
+): ExportedTaskInput {
   return {
-    id: createTaskId("task-1"),
+    localTaskId: createTaskId("task-1"),
     title: "Sync comments",
     description: "Test task",
     status: "active",
     priority: "medium",
-    projectId: binding.projectId,
     labels: [],
-    assigneeActorIds: [],
     assignees: [],
     comments,
-    createdAt: "2026-03-12T00:00:00.000Z",
     updatedAt,
   };
 }
@@ -324,17 +321,13 @@ describe("forgejo comments", () => {
     const task = createTask(
       [
         {
-          id: createNoteId("note-existing"),
-          content: "Updated local body",
-          author: "bob",
-          tags: [],
+          localNoteId: createNoteId("note-existing"),
+          body: "Updated local body",
           createdAt: "2026-03-12T03:00:00.000Z",
         },
         {
-          id: createNoteId("note-new"),
-          content: "Brand new local note",
-          author: "bob",
-          tags: [],
+          localNoteId: createNoteId("note-new"),
+          body: "Brand new local note",
           createdAt: "2026-03-12T04:00:00.000Z",
         },
       ],
@@ -361,11 +354,11 @@ describe("forgejo comments", () => {
     expect(result.updatedComments).toHaveLength(1);
     expect(result.updatedComments[0].id).toBe(21);
     expect(result.updatedComments[0].body).toBe(
-      "_Synced from todu comment by @bob on 2026-03-12T03:00:00.000Z_\n\nUpdated local body"
+      "_Synced from todu comment by @todu on 2026-03-12T03:00:00.000Z_\n\nUpdated local body"
     );
     expect(result.createdComments).toHaveLength(1);
     expect(result.createdComments[0].body).toBe(
-      "_Synced from todu comment by @bob on 2026-03-12T04:00:00.000Z_\n\nBrand new local note"
+      "_Synced from todu comment by @todu on 2026-03-12T04:00:00.000Z_\n\nBrand new local note"
     );
     expect(commentLinkStore.getByNoteId(binding.id, createNoteId("note-new"))).toMatchObject({
       lastMirroredBody: "Brand new local note",
@@ -445,13 +438,11 @@ describe("forgejo comments", () => {
     const task = createTask(
       [
         {
-          id: createNoteId("external:21"),
-          content: formatAttributedBody(
+          localNoteId: createNoteId("external:21"),
+          body: formatAttributedBody(
             formatForgejoAttribution("alice", "2026-03-12T00:00:00.000Z"),
             "Edited imported body"
           ),
-          author: "alice",
-          tags: [],
           createdAt: "2026-03-12T00:00:00.000Z",
         },
       ],
@@ -469,7 +460,7 @@ describe("forgejo comments", () => {
 
     expect(result.updatedComments).toHaveLength(1);
     expect(result.updatedComments[0].body).toBe(
-      "_Synced from todu comment by @alice on 2026-03-12T00:00:00.000Z_\n\nEdited imported body"
+      "_Synced from todu comment by @todu on 2026-03-12T00:00:00.000Z_\n\nEdited imported body"
     );
     expect(commentLinkStore.getByNoteId(binding.id, createNoteId("external:21"))).toMatchObject({
       lastMirroredBody: "Edited imported body",
@@ -532,10 +523,8 @@ describe("forgejo comments", () => {
       tasks: [
         createTask([
           {
-            id: createNoteId("note-existing"),
-            content: "Existing body",
-            author: "bob",
-            tags: [],
+            localNoteId: createNoteId("note-existing"),
+            body: "Existing body",
             createdAt: "2026-03-12T01:00:00.000Z",
           },
         ]),
@@ -603,16 +592,17 @@ describe("forgejo comments", () => {
       tasks: [
         createTask([
           {
-            id: createNoteId("note-real"),
-            content: "Remote changed body",
-            author: "bob",
-            tags: ["sync:externalId:21"],
+            localNoteId: createNoteId("note-real"),
+            body: "Remote changed body",
             createdAt: "2026-03-12T00:00:00.000Z",
           },
         ]),
       ],
       itemLinkStore,
       commentLinkStore,
+      loadTaskNotes: async () => [
+        { id: String(createNoteId("note-real")), tags: ["sync:externalId:21"] },
+      ],
     });
 
     expect(result.commentLinks).toEqual([
@@ -763,23 +753,19 @@ describe("forgejo comments", () => {
     const task = createTask(
       [
         {
-          id: createNoteId("external:21"),
-          content: formatAttributedBody(
+          localNoteId: createNoteId("external:21"),
+          body: formatAttributedBody(
             formatForgejoAttribution("alice", "2026-03-12T00:00:00.000Z"),
             "Remote changed body"
           ),
-          author: "alice",
-          tags: [],
           createdAt: "2026-03-12T00:00:00.000Z",
         },
         {
-          id: createNoteId("external:99"),
-          content: formatAttributedBody(
+          localNoteId: createNoteId("external:99"),
+          body: formatAttributedBody(
             formatForgejoAttribution("alice", "2026-03-12T00:00:00.000Z"),
             "Unlinked imported body"
           ),
-          author: "alice",
-          tags: [],
           createdAt: "2026-03-12T00:00:00.000Z",
         },
       ],

--- a/src/forgejo-comments.ts
+++ b/src/forgejo-comments.ts
@@ -3,12 +3,8 @@ import type {
   ExportedTaskInput,
   ImportedCommentInput,
   IntegrationBinding,
-  Note,
   NoteId,
   SyncProviderPushCommentLink,
-  TaskPriority,
-  TaskPushPayload,
-  TaskStatus,
 } from "@todu/core";
 
 import {
@@ -27,17 +23,14 @@ const IMPORTED_COMMENT_LINK_PREFIX = "external:";
 const SYNC_EXTERNAL_ID_TAG_PREFIX = "sync:externalId:";
 const TODU_COMMENT_AUTHOR = "todu";
 
-interface ForgejoLegacyPushTask {
-  id: string;
-  comments: Note[];
-  title: string;
-  status: TaskStatus;
-  priority: TaskPriority;
-  labels: string[];
+interface ForgejoPushNote {
+  id: ExportedCommentInput["localNoteId"];
+  content: ExportedCommentInput["body"];
+  tags: string[];
+  author: string;
+  createdAt: ExportedCommentInput["createdAt"];
+  updatedAt?: ExportedCommentInput["updatedAt"];
 }
-
-type ForgejoPushTask = ExportedTaskInput | TaskPushPayload | ForgejoLegacyPushTask;
-type ForgejoPushComment = ExportedCommentInput | Note;
 
 export function formatForgejoAttribution(author: string, timestamp: string): string {
   return `_Synced from Forgejo comment by @${author} on ${timestamp}_`;
@@ -77,7 +70,7 @@ export function hasForgejoAttribution(body: string): boolean {
   );
 }
 
-function hasImportedForgejoSyncTag(note: Pick<Note, "tags">): boolean {
+function hasImportedForgejoSyncTag(note: Pick<ForgejoPushNote, "tags">): boolean {
   return note.tags.some((tag) => tag.startsWith(SYNC_EXTERNAL_ID_TAG_PREFIX));
 }
 
@@ -85,7 +78,7 @@ function isLegacyImportedCommentLinkNoteId(noteId: NoteId): boolean {
   return String(noteId).startsWith(IMPORTED_COMMENT_LINK_PREFIX);
 }
 
-function getImportedForgejoSyncExternalId(note: Pick<Note, "tags">): string | null {
+function getImportedForgejoSyncExternalId(note: Pick<ForgejoPushNote, "tags">): string | null {
   const syncTag = note.tags.find((tag) => tag.startsWith(SYNC_EXTERNAL_ID_TAG_PREFIX));
   return syncTag ? syncTag.slice(SYNC_EXTERNAL_ID_TAG_PREFIX.length) : null;
 }
@@ -213,9 +206,12 @@ export async function pushComments(input: {
     owner: string;
     repo: string;
   };
-  tasks: ForgejoPushTask[];
+  tasks: ExportedTaskInput[];
   itemLinkStore: ForgejoItemLinkStore;
   commentLinkStore: ForgejoCommentLinkStore;
+  loadTaskNotes?: (
+    taskId: ExportedTaskInput["localTaskId"]
+  ) => Promise<Array<{ id: string; tags: string[] }>>;
   onStaleLink?: (context: PushCommentsStaleLinkContext) => void | Promise<void>;
 }): Promise<PushCommentsResult> {
   const commentLinks: SyncProviderPushCommentLink[] = [];
@@ -223,16 +219,19 @@ export async function pushComments(input: {
   const updatedComments: ForgejoComment[] = [];
 
   for (const task of input.tasks) {
-    const localTaskId = getLocalTaskId(task);
-    const itemLink = input.itemLinkStore.getByTaskId(input.binding.id, localTaskId as never);
+    const itemLink = input.itemLinkStore.getByTaskId(input.binding.id, task.localTaskId as never);
     if (!itemLink) {
       continue;
     }
 
-    const notes = (task.comments as ForgejoPushComment[]).map((comment) => toPushNote(comment));
+    const taskNotes = input.loadTaskNotes ? await input.loadTaskNotes(task.localTaskId) : [];
+    const noteTagsById = new Map(taskNotes.map((note) => [String(note.id), note.tags]));
+    const notes = task.comments.map((comment) =>
+      toPushNote(comment, noteTagsById.get(String(comment.localNoteId)) ?? [])
+    );
     reconcileLegacyCommentLinks(input.binding.id, itemLink, notes, input.commentLinkStore);
 
-    const currentNoteIds = new Set(notes.map((note) => String(note.id)));
+    const currentNoteIds = new Set(task.comments.map((comment) => String(comment.localNoteId)));
 
     for (const existingCommentLink of input.commentLinkStore.listByIssue(
       input.binding.id,
@@ -250,7 +249,13 @@ export async function pushComments(input: {
     }
 
     for (const note of notes) {
-      const existingLink = input.commentLinkStore.getByNoteId(input.binding.id, note.id);
+      const existingLink = resolveCommentLinkForPush({
+        binding: input.binding,
+        taskId: task.localTaskId,
+        itemLink,
+        note,
+        commentLinkStore: input.commentLinkStore,
+      });
 
       if (
         !existingLink &&
@@ -279,86 +284,101 @@ export async function pushComments(input: {
   return { commentLinks, createdComments, updatedComments };
 }
 
-function getLocalTaskId(task: ForgejoPushTask): string {
-  return "localTaskId" in task ? String(task.localTaskId) : String(task.id);
+function toPushNote(comment: ExportedCommentInput, tags: string[]): ForgejoPushNote {
+  return {
+    id: comment.localNoteId,
+    content: comment.body,
+    tags,
+    author: TODU_COMMENT_AUTHOR,
+    createdAt: comment.createdAt,
+    updatedAt: comment.updatedAt,
+  };
 }
 
-function toPushNote(
-  comment: ForgejoPushComment
-): Pick<Note, "id" | "content" | "tags" | "author" | "createdAt"> {
-  if ("localNoteId" in comment) {
-    return {
-      id: comment.localNoteId,
-      content: comment.body,
-      tags: [],
-      author: TODU_COMMENT_AUTHOR,
-      createdAt: comment.createdAt,
-    };
+function resolveCommentLinkForPush(input: {
+  binding: IntegrationBinding;
+  taskId: ExportedTaskInput["localTaskId"];
+  itemLink: ForgejoItemLink;
+  note: ForgejoPushNote;
+  commentLinkStore: ForgejoCommentLinkStore;
+}): ForgejoCommentLink | null {
+  const existingLink = input.commentLinkStore.getByNoteId(input.binding.id, input.note.id);
+  const syncExternalCommentId = getImportedForgejoSyncExternalId(input.note);
+
+  if (syncExternalCommentId === null) {
+    return existingLink;
   }
 
-  return {
-    id: comment.id,
-    content: comment.content,
-    tags: comment.tags,
-    author: comment.author,
-    createdAt: comment.createdAt,
+  const forgejoCommentId = Number(syncExternalCommentId);
+  const canonicalLink = input.commentLinkStore.getByForgejoCommentId(
+    input.binding.id,
+    forgejoCommentId
+  );
+  const reconciledLink: ForgejoCommentLink = {
+    bindingId: input.binding.id,
+    taskId: input.taskId,
+    noteId: input.note.id,
+    issueNumber: input.itemLink.issueNumber,
+    forgejoCommentId,
+    lastMirroredAt:
+      canonicalLink?.lastMirroredAt ??
+      existingLink?.lastMirroredAt ??
+      input.note.updatedAt ??
+      input.note.createdAt,
+    lastMirroredBody:
+      canonicalLink?.lastMirroredBody ??
+      existingLink?.lastMirroredBody ??
+      stripAttribution(input.note.content),
   };
+
+  if (existingLink && existingLink.forgejoCommentId !== forgejoCommentId) {
+    input.commentLinkStore.remove(input.binding.id, input.note.id);
+  }
+
+  if (
+    canonicalLink?.noteId !== input.note.id ||
+    canonicalLink?.taskId !== input.taskId ||
+    canonicalLink?.issueNumber !== input.itemLink.issueNumber ||
+    existingLink?.forgejoCommentId !== forgejoCommentId
+  ) {
+    input.commentLinkStore.save(reconciledLink);
+  }
+
+  return canonicalLink?.noteId === input.note.id ? canonicalLink : reconciledLink;
 }
 
 function reconcileLegacyCommentLinks(
   bindingId: IntegrationBinding["id"],
   itemLink: ForgejoItemLink,
-  notes: Array<Pick<Note, "id" | "content" | "tags">>,
+  notes: ForgejoPushNote[],
   commentLinkStore: ForgejoCommentLinkStore
 ): void {
   for (const existingLink of commentLinkStore.listByIssue(bindingId, itemLink.issueNumber)) {
-    const noteWithMatchingSyncTag = notes.find(
-      (note) => getImportedForgejoSyncExternalId(note) === String(existingLink.forgejoCommentId)
-    );
-    const noteWithSameId = notes.find((note) => note.id === existingLink.noteId);
-    const taggedForgejoCommentId = noteWithSameId
-      ? getImportedForgejoSyncExternalId(noteWithSameId)
-      : null;
     const resolvedNoteId = isLegacyImportedCommentLinkNoteId(existingLink.noteId)
       ? resolveLegacyCommentLinkNoteId(existingLink, notes)
       : existingLink.noteId;
-    const resolvedForgejoCommentId = taggedForgejoCommentId
-      ? Number(taggedForgejoCommentId)
-      : existingLink.forgejoCommentId;
 
     if (resolvedNoteId === null) {
       continue;
     }
 
-    const nextNoteId = noteWithMatchingSyncTag?.id ?? resolvedNoteId;
-
-    if (
-      existingLink.taskId === itemLink.taskId &&
-      existingLink.noteId === nextNoteId &&
-      existingLink.forgejoCommentId === resolvedForgejoCommentId
-    ) {
+    if (existingLink.taskId === itemLink.taskId && existingLink.noteId === resolvedNoteId) {
       continue;
     }
 
     commentLinkStore.save({
       ...existingLink,
       taskId: itemLink.taskId,
-      noteId: nextNoteId,
-      forgejoCommentId: resolvedForgejoCommentId,
+      noteId: resolvedNoteId,
     });
   }
 }
 
 function resolveLegacyCommentLinkNoteId(
   existingLink: ForgejoCommentLink,
-  notes: Array<Pick<Note, "id" | "content" | "tags">>
+  notes: ForgejoPushNote[]
 ): NoteId | null {
   const matchingNotes = notes.filter((note) => {
-    const importedExternalId = getImportedForgejoSyncExternalId(note);
-    if (importedExternalId === String(existingLink.forgejoCommentId)) {
-      return true;
-    }
-
     if (!hasForgejoAttribution(note.content)) {
       return false;
     }
@@ -388,13 +408,13 @@ async function updateForgejoCommentIfNeeded(
     };
     commentLinkStore: ForgejoCommentLinkStore;
   },
-  note: Pick<Note, "id" | "content" | "author" | "createdAt">,
+  note: ForgejoPushNote,
   existingLink: ForgejoCommentLink,
   updatedComments: ForgejoComment[]
 ): Promise<ForgejoComment | null> {
   const localBody = stripAttribution(note.content);
   const mirroredBody = existingLink.lastMirroredBody ?? localBody;
-  const noteUpdatedAt = Date.parse(note.createdAt);
+  const noteUpdatedAt = Date.parse(note.updatedAt ?? note.createdAt);
   const lastMirroredAt = Date.parse(existingLink.lastMirroredAt);
 
   if (
@@ -443,7 +463,7 @@ async function createForgejoCommentFromNote(
     };
     commentLinkStore: ForgejoCommentLinkStore;
   },
-  note: Pick<Note, "id" | "content" | "author" | "createdAt">,
+  note: ForgejoPushNote,
   itemLink: ForgejoItemLink,
   createdComments: ForgejoComment[]
 ): Promise<ForgejoComment> {

--- a/src/forgejo-fields-hardening.test.ts
+++ b/src/forgejo-fields-hardening.test.ts
@@ -132,15 +132,14 @@ describe("label merging and filtering", () => {
 
   it("strips pre-existing status/priority from task labels before merge", () => {
     const payload = createForgejoIssueCreateFromTask({
-      id: "task-1" as never,
+      localTaskId: "task-1" as never,
       title: "Task",
       status: "inprogress",
       priority: "high",
-      projectId: "project-1" as never,
       labels: ["bug", "status:active", "priority:low"],
       assignees: [],
-      createdAt: "2026-03-12T00:00:00.000Z",
       updatedAt: "2026-03-12T00:00:00.000Z",
+      comments: [],
     });
 
     expect(payload.labels).toEqual(["bug", "status:inprogress", "priority:high"]);

--- a/src/forgejo-fields.test.ts
+++ b/src/forgejo-fields.test.ts
@@ -8,17 +8,15 @@ import {
 describe("forgejo fields", () => {
   it("maps task fields into forgejo issue payloads", () => {
     const payload = createForgejoIssueCreateFromTask({
-      id: "task-1" as never,
+      localTaskId: "task-1" as never,
       title: "Ship feature",
       description: "Markdown body",
       status: "inprogress",
       priority: "high",
-      projectId: "project-1" as never,
       labels: ["bug", "priority:low"],
-      assigneeActorIds: [],
       assignees: [],
-      createdAt: "2026-03-12T00:00:00.000Z",
       updatedAt: "2026-03-12T00:00:00.000Z",
+      comments: [],
     });
 
     expect(payload).toEqual({

--- a/src/forgejo-fields.ts
+++ b/src/forgejo-fields.ts
@@ -1,10 +1,4 @@
-import type {
-  ExportedTaskInput,
-  ImportedTaskInput,
-  Task,
-  TaskStatus,
-  TaskWithDetail,
-} from "@todu/core";
+import type { ExportedTaskInput, ImportedTaskInput, Task, TaskStatus } from "@todu/core";
 
 import {
   createForgejoActorRef,
@@ -39,15 +33,6 @@ export interface ForgejoFieldMapping {
   labels: string[];
 }
 
-export interface ForgejoLegacyPushTaskInput {
-  title: string;
-  description?: string;
-  status: TaskStatus;
-  priority: Task["priority"];
-  labels: string[];
-  assignees?: string[];
-}
-
 export function mapForgejoIssueToImportedTask(issue: ForgejoIssue): ImportedTaskInput {
   const normalizedStatus = normalizeForgejoIssueStatus(issue.state, issue.labels);
   const normalizedPriority = normalizeForgejoIssuePriority(issue.labels);
@@ -70,9 +55,7 @@ export function mapForgejoIssueToImportedTask(issue: ForgejoIssue): ImportedTask
   };
 }
 
-export function createForgejoIssueCreateFromTask(
-  task: TaskWithDetail | ExportedTaskInput | ForgejoLegacyPushTaskInput
-): CreateForgejoIssueInput {
+export function createForgejoIssueCreateFromTask(task: ExportedTaskInput): CreateForgejoIssueInput {
   const normalizedStatus = createForgejoStatusFromTask(task.status);
   const normalizedPriority = createForgejoPriorityFromTask(task.priority);
 
@@ -89,9 +72,7 @@ export function createForgejoIssueCreateFromTask(
   };
 }
 
-export function createForgejoIssueUpdateFromTask(
-  task: TaskWithDetail | ExportedTaskInput | ForgejoLegacyPushTaskInput
-): UpdateForgejoIssueInput {
+export function createForgejoIssueUpdateFromTask(task: ExportedTaskInput): UpdateForgejoIssueInput {
   return createForgejoIssueCreateFromTask(task);
 }
 
@@ -211,25 +192,14 @@ function parseTaskPriorityFromLabel(label: string): Task["priority"] {
   return label.slice(PRIORITY_LABEL_PREFIX.length) as Task["priority"];
 }
 
-function getOutboundForgejoAssignees(
-  task: TaskWithDetail | ExportedTaskInput | ForgejoLegacyPushTaskInput
-): string[] | undefined {
-  if ("assignees" in task && Array.isArray(task.assignees)) {
-    const assignees = task.assignees.flatMap((assignee) => {
-      if (typeof assignee === "string") {
-        const normalized = assignee.trim();
-        return normalized ? [normalized] : [];
-      }
+function getOutboundForgejoAssignees(task: ExportedTaskInput): string[] | undefined {
+  const assignees = task.assignees.flatMap((assignee) => {
+    const normalized =
+      assignee.externalLogin?.trim() ||
+      assignee.displayName?.trim() ||
+      assignee.externalAccountId?.trim();
+    return normalized ? [normalized] : [];
+  });
 
-      const normalized =
-        assignee.externalLogin?.trim() ||
-        assignee.displayName?.trim() ||
-        assignee.externalAccountId?.trim();
-      return normalized ? [normalized] : [];
-    });
-
-    return assignees.length > 0 ? assignees : undefined;
-  }
-
-  return undefined;
+  return assignees.length > 0 ? assignees : undefined;
 }

--- a/src/forgejo-provider-hardening.test.ts
+++ b/src/forgejo-provider-hardening.test.ts
@@ -3,8 +3,8 @@ import {
   createNoteId,
   createProjectId,
   createTaskId,
+  type ExportedTaskInput,
   type IntegrationBinding,
-  type TaskPushPayload,
 } from "@todu/core";
 
 import { createInMemoryForgejoCommentLinkStore } from "@/forgejo-comment-links";
@@ -47,19 +47,16 @@ const target = {
   repo: "roadmap",
 };
 
-function createPushTask(overrides: Partial<TaskPushPayload> = {}): TaskPushPayload {
+function createPushTask(overrides: Partial<ExportedTaskInput> = {}): ExportedTaskInput {
   return {
-    id: createTaskId("task-1"),
+    localTaskId: createTaskId("task-1"),
     title: "Test task",
     description: "",
     status: "active",
     priority: "medium",
-    projectId: createBinding().projectId,
     labels: [],
-    assigneeActorIds: overrides.assigneeActorIds ?? [],
     assignees: [],
     comments: [],
-    createdAt: "2026-03-12T00:00:00.000Z",
     updatedAt: "2026-03-12T00:00:00.000Z",
     ...overrides,
   };
@@ -305,7 +302,7 @@ describe("provider error classification coverage", () => {
       createBinding(),
       [
         createPushTask({
-          id: createTaskId("task-1"),
+          localTaskId: createTaskId("task-1"),
           externalId: "https://code.example.com/acme/roadmap#7",
           comments: [],
         }),
@@ -524,11 +521,9 @@ describe("provider push failure handling", () => {
           updatedAt: "2026-03-12T02:00:00.000Z",
           comments: [
             {
-              id: createNoteId("note-1"),
-              content: "Updated local note",
-              author: "alice",
+              localNoteId: createNoteId("note-1"),
+              body: "Updated local note",
               createdAt: "2026-03-12T02:00:00.000Z",
-              tags: [],
             },
           ],
         }),

--- a/src/forgejo-provider.test.ts
+++ b/src/forgejo-provider.test.ts
@@ -2,8 +2,8 @@ import {
   createIntegrationBindingId,
   createProjectId,
   createTaskId,
+  type ExportedTaskInput,
   type IntegrationBinding,
-  type TaskPushPayload,
 } from "@todu/core";
 
 import { FORGEJO_PROVIDER_NAME, FORGEJO_REPOSITORY_TARGET_KIND } from "@/forgejo-binding";
@@ -38,6 +38,21 @@ const project = {
   createdAt: "2026-03-12T00:00:00.000Z",
   updatedAt: "2026-03-12T00:00:00.000Z",
 };
+
+function createExportedTask(overrides: Partial<ExportedTaskInput> = {}): ExportedTaskInput {
+  return {
+    localTaskId: createTaskId("task-1"),
+    title: "Test task",
+    description: "",
+    status: "active",
+    priority: "medium",
+    labels: [],
+    assignees: [],
+    updatedAt: "2026-03-12T00:00:00.000Z",
+    comments: [],
+    ...overrides,
+  };
+}
 
 describe("forgejo provider", () => {
   it("exports initialized settings after initialize and resets on shutdown", async () => {
@@ -413,21 +428,12 @@ describe("forgejo provider runtime integration", () => {
       },
     });
 
-    const tasks: TaskPushPayload[] = [
-      {
-        id: createTaskId("task-loop"),
+    const tasks: ExportedTaskInput[] = [
+      createExportedTask({
+        localTaskId: createTaskId("task-loop"),
         title: "Loop test",
-        description: "",
-        status: "active",
-        priority: "medium",
-        projectId: createBinding().projectId,
-        labels: [],
-        assigneeActorIds: [],
-        assignees: ["caradoc"],
-        comments: [],
-        createdAt: "2026-03-12T00:00:00.000Z",
-        updatedAt: "2026-03-12T00:00:00.000Z",
-      },
+        assignees: [{ externalLogin: "caradoc", displayName: "caradoc" }],
+      }),
     ];
 
     await provider.push(createBinding(), tasks, project);
@@ -523,20 +529,11 @@ describe("forgejo provider runtime integration", () => {
     await provider.push(
       createBinding(),
       [
-        {
-          id: createTaskId("task-7"),
+        createExportedTask({
+          localTaskId: createTaskId("task-7"),
           title: "Unchanged task",
-          description: "",
-          status: "active",
-          priority: "medium",
-          projectId: createBinding().projectId,
-          labels: [],
-          assigneeActorIds: [],
-          assignees: [],
-          comments: [],
-          createdAt: "2026-03-12T00:00:00.000Z",
           updatedAt: "2026-03-12T01:00:00.000Z",
-        },
+        }),
       ],
       project
     );
@@ -593,26 +590,17 @@ describe("forgejo provider runtime integration", () => {
       },
     });
 
-    const firstTask: TaskPushPayload = {
-      id: createTaskId("task-loop"),
+    const firstTask: ExportedTaskInput = createExportedTask({
+      localTaskId: createTaskId("task-loop"),
       title: "Loop test updated",
-      description: "",
-      status: "active",
-      priority: "medium",
-      projectId: createBinding().projectId,
-      labels: [],
-      assigneeActorIds: [],
-      assignees: [],
-      comments: [],
-      createdAt: "2026-03-12T00:00:00.000Z",
       updatedAt: "2026-03-12T01:00:00.000Z",
-    };
+    });
 
     await provider.push(createBinding(), [firstTask], project);
     expect(updateCallCount).toBe(1);
 
     const issueUpdatedAt = issueClient.snapshotIssues(target)[0].updatedAt!;
-    const secondTask: TaskPushPayload = {
+    const secondTask: ExportedTaskInput = {
       ...firstTask,
       updatedAt: issueUpdatedAt,
     };

--- a/src/forgejo-provider.ts
+++ b/src/forgejo-provider.ts
@@ -9,7 +9,6 @@ import {
   type SyncProviderPushResult,
   type SyncProviderRegistration,
   type SyncProviderV3,
-  type TaskPushPayload,
 } from "@todu/core";
 
 import {
@@ -94,7 +93,7 @@ export interface ForgejoProviderState {
 export interface ForgejoSyncProvider extends SyncProviderV3 {
   push(
     binding: IntegrationBinding,
-    tasks: ExportedTaskInput[] | TaskPushPayload[],
+    tasks: ExportedTaskInput[],
     project: Parameters<SyncProviderV3["push"]>[2]
   ): Promise<SyncProviderPushResult>;
   getState(): ForgejoProviderState;
@@ -109,6 +108,9 @@ export interface CreateForgejoSyncProviderOptions {
   logger?: ForgejoSyncLogger;
   retryConfig?: ForgejoRetryConfig;
   initialConfig?: SyncProviderConfig | null;
+  loadTaskNotes?: (
+    taskId: ExportedTaskInput["localTaskId"]
+  ) => Promise<Array<{ id: string; tags: string[] }>>;
 }
 
 export function createForgejoRepositoryTarget(
@@ -347,11 +349,7 @@ export function createForgejoSyncProvider(
         throw error;
       }
     },
-    async push(
-      binding,
-      tasks: ExportedTaskInput[] | TaskPushPayload[],
-      _project
-    ): Promise<SyncProviderPushResult> {
+    async push(binding, tasks: ExportedTaskInput[], _project): Promise<SyncProviderPushResult> {
       const parsedBinding = validateBinding(binding);
       const currentSettings = requireInitializedSettings();
       const target = createForgejoRepositoryTarget(parsedBinding, currentSettings);
@@ -393,7 +391,7 @@ export function createForgejoSyncProvider(
           apiBaseUrl: target.apiBaseUrl,
           owner: target.owner,
           repo: target.repo,
-          tasks: tasks as ExportedTaskInput[],
+          tasks,
           issueClient,
           linkStore,
           commentLinkStore,
@@ -435,9 +433,10 @@ export function createForgejoSyncProvider(
           binding,
           issueClient,
           target,
-          tasks: tasks as ExportedTaskInput[],
+          tasks,
           itemLinkStore: linkStore,
           commentLinkStore,
+          loadTaskNotes: options.loadTaskNotes,
           onStaleLink: ({ itemLink, commentLink }) => {
             logger.warn("removing stale comment link for missing local note", {
               ...logContext,


### PR DESCRIPTION
## Summary
- remove legacy push-task compatibility unions from the Forgejo provider push path
- narrow bootstrap, comments, and field mapping to the v3 exported task/comment contract
- update tests to use the supported v3 input shape while preserving comment-link reconciliation coverage

## Verification
- npm run format
- npm run lint
- npm run typecheck
- npm test

Task: task-bc18940f