### PR TITLE
Fix Forgejo storage path handling

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+coverage/
+.dev/
+.todu-*-plugin/

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -184,7 +184,7 @@ Inside `storageDir`, the plugin should keep separate files or equivalent DB coll
 - `runtime-state.json`
 - optional diagnostics/error snapshots
 
-Legacy migration only moves the known state files above. It leaves unrelated files in place, removes the legacy directory only if it becomes empty, and fails clearly rather than overwriting current state.
+Legacy migration only moves the known state files above. It leaves unrelated files in place, removes the legacy directory only if it becomes empty, and fails clearly rather than overwriting current state. Operators can run `npm run migrate:forgejo-storage -- --from <absolute-old-dir> --to <absolute-new-dir>` on each affected machine before changing config; the script is dry-run by default and requires `--write` to move files. `settings.legacyStorageDir` remains available for one-time daemon-start migration when a scripted migration is not practical.
 
 ### Authentication differences vs GitHub
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -161,7 +161,7 @@ Recommended config shape:
   "settings": {
     "baseUrl": "https://code.example.com",
     "token": "<forgejo-pat>",
-    "storageDir": ".todu-forgejo-plugin"
+    "storageDir": "/var/lib/todu/forgejo-plugin"
   }
 }
 ```
@@ -170,16 +170,21 @@ Recommended config shape:
 
 - `settings.baseUrl` — required. Base web URL for the Forgejo instance. The plugin derives API paths from this.
 - `settings.token` — required. Personal access token used for all bindings.
-- `settings.storageDir` — optional. Directory for plugin-owned local state. When omitted, the provider keeps local state in memory for the current process only.
+- `settings.storageDir` — optional. Directory for plugin-owned local state. When omitted, the provider keeps local state in memory for the current process only. Absolute paths are used directly. Relative paths are resolved under the provider's stable app-owned state root instead of the daemon cwd, so durable state does not depend on where the daemon was started.
+- `settings.legacyStorageDir` — optional absolute path to a previous cwd-relative Forgejo plugin state directory. When provided with `settings.storageDir`, the provider migrates known state files from the legacy directory without overwriting existing destination files.
+
+The stable app-owned state root is `~/Library/Application Support/todu/forgejo-plugin` on macOS, `${XDG_STATE_HOME:-~/.local/state}/todu/forgejo-plugin` on Linux, and `%LOCALAPPDATA%\\todu\\forgejo-plugin` on Windows.
 
 ### Derived local files
 
 Inside `storageDir`, the plugin should keep separate files or equivalent DB collections for:
 
-- item links
-- comment links
-- binding runtime state
+- `item-links.json`
+- `comment-links.json`
+- `runtime-state.json`
 - optional diagnostics/error snapshots
+
+Legacy migration only moves the known state files above. It leaves unrelated files in place, removes the legacy directory only if it becomes empty, and fails clearly rather than overwriting current state.
 
 ### Authentication differences vs GitHub
 

--- a/docs/SMOKE-TEST.md
+++ b/docs/SMOKE-TEST.md
@@ -30,8 +30,10 @@ make dev
 ### 3. Configure the plugin
 
 ```bash
-make dev-cli CMD="plugin config forgejo --set '{\"settings\":{\"baseUrl\":\"https://your-forgejo.example.com\",\"token\":\"YOUR_TOKEN\",\"storageDir\":\".dev/todu/forgejo-plugin-state\"},\"intervalSeconds\":30}'"
+make dev-cli CMD="plugin config forgejo --set '{\"settings\":{\"baseUrl\":\"https://your-forgejo.example.com\",\"token\":\"YOUR_TOKEN\",\"storageDir\":\"'\"${PWD}\"'/.dev/todu/forgejo-plugin-state\"},\"intervalSeconds\":30}'"
 ```
+
+If migrating state from an old cwd-relative directory, add `legacyStorageDir` with the absolute old path for one startup. The provider moves `item-links.json`, `comment-links.json`, and `runtime-state.json` into `storageDir` without overwriting destination files.
 
 ### 4. Create a project and integration binding
 

--- a/docs/SMOKE-TEST.md
+++ b/docs/SMOKE-TEST.md
@@ -33,7 +33,20 @@ make dev
 make dev-cli CMD="plugin config forgejo --set '{\"settings\":{\"baseUrl\":\"https://your-forgejo.example.com\",\"token\":\"YOUR_TOKEN\",\"storageDir\":\"'\"${PWD}\"'/.dev/todu/forgejo-plugin-state\"},\"intervalSeconds\":30}'"
 ```
 
-If migrating state from an old cwd-relative directory, add `legacyStorageDir` with the absolute old path for one startup. The provider moves `item-links.json`, `comment-links.json`, and `runtime-state.json` into `storageDir` without overwriting destination files.
+If migrating state from an old cwd-relative directory, use the migration script on each machine before starting the daemon with the new config:
+
+```bash
+npm run migrate:forgejo-storage -- \
+  --from /absolute/path/to/old/.todu-forgejo-plugin \
+  --to "${PWD}/.dev/todu/forgejo-plugin-state"
+
+npm run migrate:forgejo-storage -- \
+  --from /absolute/path/to/old/.todu-forgejo-plugin \
+  --to "${PWD}/.dev/todu/forgejo-plugin-state" \
+  --write
+```
+
+The script is dry-run by default and moves only `item-links.json`, `comment-links.json`, and `runtime-state.json` without overwriting destination files. For one-time daemon-start migration, you can instead add `legacyStorageDir` with the absolute old path for one startup.
 
 ### 4. Create a project and integration binding
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test:integration": "vitest run --config vitest.integration.config.ts",
     "test:coverage": "vitest run --coverage",
     "repair:forgejo-comment-links": "node ./scripts/reconcile-forgejo-comment-links.mjs",
+    "migrate:forgejo-storage": "node ./scripts/migrate-forgejo-storage.mjs",
     "check": "npm run lint && npm test",
     "pre-pr": "./scripts/pre-pr.sh"
   },

--- a/scripts/migrate-forgejo-storage.mjs
+++ b/scripts/migrate-forgejo-storage.mjs
@@ -1,0 +1,266 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const FORGEJO_STORAGE_STATE_FILES = ["item-links.json", "comment-links.json", "runtime-state.json"];
+
+function parseArgs(argv) {
+  const args = {
+    from: null,
+    to: getForgejoAppStateRoot(),
+    write: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === "--from") {
+      args.from = requireValue(argv, ++index, arg);
+      continue;
+    }
+
+    if (arg === "--to") {
+      args.to = requireValue(argv, ++index, arg);
+      continue;
+    }
+
+    if (arg === "--write") {
+      args.write = true;
+      continue;
+    }
+
+    if (arg === "--dry-run") {
+      args.write = false;
+      continue;
+    }
+
+    if (arg === "-h" || arg === "--help") {
+      printHelp();
+      process.exit(0);
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  if (!args.from) {
+    throw new Error("Missing required --from <legacy-storage-dir>");
+  }
+
+  return {
+    from: requireAbsolutePath(expandHomePath(args.from), "--from"),
+    to: requireAbsolutePath(expandHomePath(args.to), "--to"),
+    write: args.write,
+  };
+}
+
+function requireValue(argv, index, flag) {
+  const value = argv[index];
+  if (!value) {
+    throw new Error(`Missing value for ${flag}`);
+  }
+
+  return value;
+}
+
+function printHelp() {
+  console.log(`Usage: node scripts/migrate-forgejo-storage.mjs --from <legacy-storage-dir> [options]
+
+Dry-run by default. Moves known Forgejo plugin state files from an old cwd-relative
+storage directory into a stable storage directory without overwriting existing files.
+
+Options:
+  --from <path>   absolute path to old .todu-forgejo-plugin directory (required)
+  --to <path>     absolute destination storage directory
+                  default: ${getForgejoAppStateRoot()}
+  --write         perform the move; otherwise only print planned actions
+  --dry-run       print planned actions without moving files (default)
+  -h, --help      show help
+
+Known state files:
+  ${FORGEJO_STORAGE_STATE_FILES.join("\n  ")}
+`);
+}
+
+function getForgejoAppStateRoot() {
+  if (process.platform === "darwin") {
+    return path.join(os.homedir(), "Library", "Application Support", "todu", "forgejo-plugin");
+  }
+
+  if (process.platform === "win32") {
+    const localAppData =
+      process.env.LOCALAPPDATA?.trim() || path.join(os.homedir(), "AppData", "Local");
+    return path.join(localAppData, "todu", "forgejo-plugin");
+  }
+
+  const xdgStateHome =
+    process.env.XDG_STATE_HOME?.trim() || path.join(os.homedir(), ".local", "state");
+  return path.join(xdgStateHome, "todu", "forgejo-plugin");
+}
+
+function expandHomePath(inputPath) {
+  if (inputPath === "~") {
+    return os.homedir();
+  }
+
+  if (inputPath.startsWith("~/") || inputPath.startsWith("~\\")) {
+    return path.join(os.homedir(), inputPath.slice(2));
+  }
+
+  return inputPath;
+}
+
+function requireAbsolutePath(inputPath, flag) {
+  if (!path.isAbsolute(inputPath)) {
+    throw new Error(`${flag} must be an absolute path`);
+  }
+
+  return path.normalize(inputPath);
+}
+
+function isNodeError(error) {
+  return error instanceof Error && "code" in error;
+}
+
+function moveFileWithoutOverwrite(sourcePath, destinationPath) {
+  if (fs.existsSync(destinationPath)) {
+    throw new Error(
+      `Cannot migrate ${sourcePath}: destination already exists at ${destinationPath}`
+    );
+  }
+
+  fs.mkdirSync(path.dirname(destinationPath), { recursive: true });
+
+  try {
+    fs.renameSync(sourcePath, destinationPath);
+  } catch (error) {
+    if (!isNodeError(error) || error.code !== "EXDEV") {
+      throw error;
+    }
+
+    fs.copyFileSync(sourcePath, destinationPath, fs.constants.COPYFILE_EXCL);
+    fs.unlinkSync(sourcePath);
+  }
+}
+
+function inspectMigration(options) {
+  if (path.resolve(options.from) === path.resolve(options.to)) {
+    throw new Error("--from and --to resolve to the same directory");
+  }
+
+  if (!fs.existsSync(options.from)) {
+    throw new Error(`Legacy storage directory does not exist: ${options.from}`);
+  }
+
+  const legacyStats = fs.statSync(options.from);
+  if (!legacyStats.isDirectory()) {
+    throw new Error(`Legacy storage path is not a directory: ${options.from}`);
+  }
+
+  return FORGEJO_STORAGE_STATE_FILES.map((filename) => {
+    const sourcePath = path.join(options.from, filename);
+    const destinationPath = path.join(options.to, filename);
+
+    if (!fs.existsSync(sourcePath)) {
+      return { filename, sourcePath, destinationPath, action: "skip-missing" };
+    }
+
+    const sourceStats = fs.statSync(sourcePath);
+    if (!sourceStats.isFile()) {
+      return { filename, sourcePath, destinationPath, action: "error-not-file" };
+    }
+
+    if (fs.existsSync(destinationPath)) {
+      return { filename, sourcePath, destinationPath, action: "error-destination-exists" };
+    }
+
+    return { filename, sourcePath, destinationPath, action: "move" };
+  });
+}
+
+function printPlan(options, plan) {
+  console.log(`Forgejo storage migration (${options.write ? "write" : "dry-run"})`);
+  console.log(`From: ${options.from}`);
+  console.log(`To:   ${options.to}`);
+  console.log("");
+
+  for (const item of plan) {
+    if (item.action === "move") {
+      console.log(`MOVE  ${item.filename}`);
+      console.log(`      ${item.sourcePath}`);
+      console.log(`   -> ${item.destinationPath}`);
+      continue;
+    }
+
+    if (item.action === "skip-missing") {
+      console.log(`SKIP  ${item.filename} (missing)`);
+      continue;
+    }
+
+    if (item.action === "error-not-file") {
+      console.log(`ERROR ${item.filename} (source is not a file): ${item.sourcePath}`);
+      continue;
+    }
+
+    if (item.action === "error-destination-exists") {
+      console.log(`ERROR ${item.filename} (destination exists): ${item.destinationPath}`);
+    }
+  }
+}
+
+function applyMigration(options, plan) {
+  const blockingErrors = plan.filter((item) => item.action.startsWith("error-"));
+  if (blockingErrors.length > 0) {
+    throw new Error("Migration blocked; resolve errors above before running with --write");
+  }
+
+  let moved = 0;
+  for (const item of plan) {
+    if (item.action !== "move") {
+      continue;
+    }
+
+    moveFileWithoutOverwrite(item.sourcePath, item.destinationPath);
+    moved += 1;
+  }
+
+  if (moved > 0) {
+    try {
+      fs.rmdirSync(options.from);
+    } catch (error) {
+      if (!isNodeError(error) || (error.code !== "ENOTEMPTY" && error.code !== "ENOENT")) {
+        throw error;
+      }
+    }
+  }
+
+  return moved;
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const plan = inspectMigration(options);
+  printPlan(options, plan);
+
+  const blockingErrors = plan.filter((item) => item.action.startsWith("error-"));
+  if (blockingErrors.length > 0) {
+    process.exitCode = 1;
+    return;
+  }
+
+  if (!options.write) {
+    console.log("\nDry-run only. Re-run with --write to move files.");
+    return;
+  }
+
+  const moved = applyMigration(options, plan);
+  console.log(`\nMoved ${moved} file(s).`);
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+}

--- a/src/forgejo-config.test.ts
+++ b/src/forgejo-config.test.ts
@@ -1,7 +1,12 @@
+import os from "node:os";
+import path from "node:path";
+
 import {
   ForgejoProviderConfigError,
+  getForgejoAppStateRoot,
   loadForgejoProviderSettings,
   normalizeForgejoBaseUrl,
+  resolveForgejoStorageDir,
 } from "@/forgejo-config";
 
 describe("forgejo config", () => {
@@ -17,6 +22,7 @@ describe("forgejo config", () => {
     expect(settings.apiBaseUrl).toBe("https://code.example.com/forgejo/api/v1");
     expect(settings.token).toBe("secret-token");
     expect(settings.storageDir).toBeNull();
+    expect(settings.legacyStorageDir).toBeNull();
     expect(settings.authType).toBe("token");
   });
 
@@ -32,7 +38,20 @@ describe("forgejo config", () => {
     expect(settings.authType).toBe("bearer");
   });
 
-  it("preserves an explicit storage directory when configured", () => {
+  it("preserves an explicit absolute storage directory when configured", () => {
+    const storageDir = path.join(os.tmpdir(), "todu-forgejo-plugin-state");
+    const settings = loadForgejoProviderSettings({
+      settings: {
+        baseUrl: "https://code.example.com",
+        token: "secret-token",
+        storageDir,
+      },
+    });
+
+    expect(settings.storageDir).toBe(path.normalize(storageDir));
+  });
+
+  it("resolves relative storage directories under the app state root", () => {
     const settings = loadForgejoProviderSettings({
       settings: {
         baseUrl: "https://code.example.com",
@@ -41,7 +60,52 @@ describe("forgejo config", () => {
       },
     });
 
-    expect(settings.storageDir).toBe(".todu-forgejo-plugin");
+    expect(settings.storageDir).toBe(path.join(getForgejoAppStateRoot(), ".todu-forgejo-plugin"));
+  });
+
+  it("derives platform-specific app state roots", () => {
+    expect(getForgejoAppStateRoot({ homedir: "/Users/alice", platform: "darwin" })).toBe(
+      path.join("/Users/alice", "Library", "Application Support", "todu", "forgejo-plugin")
+    );
+    expect(getForgejoAppStateRoot({ env: {}, homedir: "/home/alice", platform: "linux" })).toBe(
+      path.join("/home/alice", ".local", "state", "todu", "forgejo-plugin")
+    );
+    expect(
+      getForgejoAppStateRoot({
+        env: { XDG_STATE_HOME: "/var/state/alice" },
+        homedir: "/home/alice",
+        platform: "linux",
+      })
+    ).toBe(path.join("/var/state/alice", "todu", "forgejo-plugin"));
+  });
+
+  it("resolves home-relative and relative storage paths", () => {
+    expect(resolveForgejoStorageDir("~/state", { homedir: "/Users/alice" })).toBe(
+      path.join("/Users/alice", "state")
+    );
+    expect(
+      resolveForgejoStorageDir("plugin-state", {
+        env: {},
+        homedir: "/home/alice",
+        platform: "linux",
+      })
+    ).toBe(path.join("/home/alice", ".local", "state", "todu", "forgejo-plugin", "plugin-state"));
+  });
+
+  it("supports an explicit absolute legacy storage directory", () => {
+    const storageDir = path.join(os.tmpdir(), "todu-forgejo-plugin-state");
+    const legacyStorageDir = path.join(os.tmpdir(), "legacy-todu-forgejo-plugin-state");
+    const settings = loadForgejoProviderSettings({
+      settings: {
+        baseUrl: "https://code.example.com",
+        token: "secret-token",
+        storageDir,
+        legacyStorageDir,
+      },
+    });
+
+    expect(settings.storageDir).toBe(path.normalize(storageDir));
+    expect(settings.legacyStorageDir).toBe(path.normalize(legacyStorageDir));
   });
 
   it("rejects missing token or base url", () => {
@@ -64,6 +128,31 @@ describe("forgejo config", () => {
           baseUrl: "https://code.example.com",
           token: "secret-token",
           authType: "basic",
+        },
+      })
+    ).toThrow(ForgejoProviderConfigError);
+  });
+
+  it("rejects relative legacy storage directories", () => {
+    expect(() =>
+      loadForgejoProviderSettings({
+        settings: {
+          baseUrl: "https://code.example.com",
+          token: "secret-token",
+          storageDir: "plugin-state",
+          legacyStorageDir: ".todu-forgejo-plugin",
+        },
+      })
+    ).toThrow(ForgejoProviderConfigError);
+  });
+
+  it("rejects legacy storage directories without storage directories", () => {
+    expect(() =>
+      loadForgejoProviderSettings({
+        settings: {
+          baseUrl: "https://code.example.com",
+          token: "secret-token",
+          legacyStorageDir: path.join(os.tmpdir(), "legacy-todu-forgejo-plugin-state"),
         },
       })
     ).toThrow(ForgejoProviderConfigError);

--- a/src/forgejo-config.ts
+++ b/src/forgejo-config.ts
@@ -1,3 +1,6 @@
+import os from "node:os";
+import path from "node:path";
+
 import type { SyncProviderConfig } from "@todu/core";
 
 export type ForgejoProviderConfigErrorCode =
@@ -5,7 +8,8 @@ export type ForgejoProviderConfigErrorCode =
   | "MISSING_BASE_URL"
   | "INVALID_BASE_URL"
   | "MISSING_TOKEN"
-  | "INVALID_AUTH_TYPE";
+  | "INVALID_AUTH_TYPE"
+  | "INVALID_STORAGE_DIR";
 
 export type ForgejoAuthType = "token" | "bearer";
 
@@ -14,6 +18,7 @@ export interface ForgejoProviderSettings {
   apiBaseUrl: string;
   token: string;
   storageDir: string | null;
+  legacyStorageDir: string | null;
   authType: ForgejoAuthType;
 }
 
@@ -68,6 +73,56 @@ export function normalizeForgejoBaseUrl(baseUrl: string): string {
   return parsedUrl.toString().replace(/\/$/, "");
 }
 
+export interface ForgejoAppStateRootOptions {
+  env?: NodeJS.ProcessEnv;
+  homedir?: string;
+  platform?: NodeJS.Platform;
+}
+
+export function getForgejoAppStateRoot(options: ForgejoAppStateRootOptions = {}): string {
+  const env = options.env ?? process.env;
+  const homedir = options.homedir ?? os.homedir();
+  const platform = options.platform ?? process.platform;
+
+  if (platform === "darwin") {
+    return path.join(homedir, "Library", "Application Support", "todu", "forgejo-plugin");
+  }
+
+  if (platform === "win32") {
+    const localAppData = env.LOCALAPPDATA?.trim() || path.join(homedir, "AppData", "Local");
+    return path.join(localAppData, "todu", "forgejo-plugin");
+  }
+
+  const xdgStateHome = env.XDG_STATE_HOME?.trim() || path.join(homedir, ".local", "state");
+  return path.join(xdgStateHome, "todu", "forgejo-plugin");
+}
+
+export function expandForgejoHomePath(inputPath: string, homedir = os.homedir()): string {
+  if (inputPath === "~") {
+    return homedir;
+  }
+
+  if (inputPath.startsWith("~/") || inputPath.startsWith("~\\")) {
+    return path.join(homedir, inputPath.slice(2));
+  }
+
+  return inputPath;
+}
+
+export function resolveForgejoStorageDir(
+  storageDir: string,
+  options: ForgejoAppStateRootOptions = {}
+): string {
+  const homedir = options.homedir ?? os.homedir();
+  const expandedStorageDir = expandForgejoHomePath(storageDir.trim(), homedir);
+
+  if (path.isAbsolute(expandedStorageDir)) {
+    return path.normalize(expandedStorageDir);
+  }
+
+  return path.resolve(getForgejoAppStateRoot(options), expandedStorageDir);
+}
+
 export function deriveForgejoApiBaseUrl(baseUrl: string): string {
   return `${normalizeForgejoBaseUrl(baseUrl)}/api/v1`;
 }
@@ -97,10 +152,47 @@ export function loadForgejoProviderSettings(config: SyncProviderConfig): Forgejo
   const storageDir = settings.storageDir;
   if (storageDir !== undefined && (typeof storageDir !== "string" || !storageDir.trim())) {
     throw new ForgejoProviderConfigError(
-      "INVALID_SETTINGS",
+      "INVALID_STORAGE_DIR",
       "Invalid Forgejo provider settings: settings.storageDir must be a non-empty string when provided",
       {
         field: "settings.storageDir",
+      }
+    );
+  }
+
+  const legacyStorageDir = settings.legacyStorageDir;
+  if (
+    legacyStorageDir !== undefined &&
+    (typeof legacyStorageDir !== "string" || !legacyStorageDir.trim())
+  ) {
+    throw new ForgejoProviderConfigError(
+      "INVALID_STORAGE_DIR",
+      "Invalid Forgejo provider settings: settings.legacyStorageDir must be a non-empty string when provided",
+      {
+        field: "settings.legacyStorageDir",
+      }
+    );
+  }
+
+  if (legacyStorageDir !== undefined && storageDir === undefined) {
+    throw new ForgejoProviderConfigError(
+      "INVALID_STORAGE_DIR",
+      "Invalid Forgejo provider settings: settings.legacyStorageDir requires settings.storageDir",
+      {
+        field: "settings.legacyStorageDir",
+      }
+    );
+  }
+
+  const resolvedLegacyStorageDir =
+    typeof legacyStorageDir === "string" ? expandForgejoHomePath(legacyStorageDir.trim()) : null;
+  if (resolvedLegacyStorageDir && !path.isAbsolute(resolvedLegacyStorageDir)) {
+    throw new ForgejoProviderConfigError(
+      "INVALID_STORAGE_DIR",
+      "Invalid Forgejo provider settings: settings.legacyStorageDir must be an absolute path",
+      {
+        field: "settings.legacyStorageDir",
+        legacyStorageDir,
       }
     );
   }
@@ -121,7 +213,8 @@ export function loadForgejoProviderSettings(config: SyncProviderConfig): Forgejo
     baseUrl,
     apiBaseUrl: deriveForgejoApiBaseUrl(baseUrl),
     token: token.trim(),
-    storageDir: typeof storageDir === "string" ? storageDir.trim() : null,
+    storageDir: typeof storageDir === "string" ? resolveForgejoStorageDir(storageDir) : null,
+    legacyStorageDir: resolvedLegacyStorageDir ? path.normalize(resolvedLegacyStorageDir) : null,
     authType: authType ?? "token",
   };
 }

--- a/src/forgejo-provider.test.ts
+++ b/src/forgejo-provider.test.ts
@@ -1,3 +1,7 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
 import {
   createIntegrationBindingId,
   createProjectId,
@@ -72,6 +76,34 @@ describe("forgejo provider", () => {
 
     await provider.shutdown();
     expect(provider.getState().initialized).toBe(false);
+  });
+
+  it("migrates explicit legacy storage before creating file-backed stores", async () => {
+    const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "todu-forgejo-provider-"));
+    const storageDir = path.join(rootDir, "state");
+    const legacyStorageDir = path.join(rootDir, "legacy");
+    fs.mkdirSync(legacyStorageDir, { recursive: true });
+    fs.writeFileSync(path.join(legacyStorageDir, "item-links.json"), "[]\n", "utf8");
+
+    try {
+      const provider = createForgejoSyncProvider({
+        issueClient: createInMemoryForgejoIssueClient(),
+      });
+      await provider.initialize({
+        settings: {
+          baseUrl: "https://code.example.com",
+          token: "secret-token",
+          storageDir,
+          legacyStorageDir,
+        },
+      });
+
+      expect(fs.existsSync(path.join(storageDir, "item-links.json"))).toBe(true);
+      expect(fs.existsSync(path.join(legacyStorageDir, "item-links.json"))).toBe(false);
+      expect(provider.getState().settings?.storageDir).toBe(storageDir);
+    } finally {
+      fs.rmSync(rootDir, { force: true, recursive: true });
+    }
   });
 
   it("validates bindings during pull and push", async () => {

--- a/src/forgejo-provider.ts
+++ b/src/forgejo-provider.ts
@@ -43,6 +43,7 @@ import {
   type ForgejoRepositoryTarget,
 } from "@/forgejo-client";
 import { loadForgejoProviderSettings, type ForgejoProviderSettings } from "@/forgejo-config";
+import { migrateForgejoLegacyStorage } from "@/forgejo-storage";
 import { createHttpForgejoIssueClient } from "@/forgejo-http-client";
 import {
   createFileForgejoItemLinkStore,
@@ -217,6 +218,9 @@ export function createForgejoSyncProvider(
         issueClient = createHttpForgejoIssueClient(settings.token, {
           authType: settings.authType,
         });
+      }
+      if (settings.storageDir) {
+        migrateForgejoLegacyStorage(settings);
       }
       if (!options.linkStore && settings.storageDir) {
         linkStore = createFileForgejoItemLinkStore(

--- a/src/forgejo-storage.test.ts
+++ b/src/forgejo-storage.test.ts
@@ -1,0 +1,92 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { migrateForgejoLegacyStorage } from "@/forgejo-storage";
+
+describe("forgejo storage", () => {
+  const tempDirs: string[] = [];
+
+  const createTempDir = (): string => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "todu-forgejo-storage-"));
+    tempDirs.push(tempDir);
+    return tempDir;
+  };
+
+  afterEach(() => {
+    for (const tempDir of tempDirs.splice(0)) {
+      fs.rmSync(tempDir, { force: true, recursive: true });
+    }
+  });
+
+  it("moves known legacy storage files into the configured storage directory", () => {
+    const rootDir = createTempDir();
+    const legacyStorageDir = path.join(rootDir, "legacy");
+    const storageDir = path.join(rootDir, "state");
+    fs.mkdirSync(legacyStorageDir, { recursive: true });
+    fs.writeFileSync(path.join(legacyStorageDir, "item-links.json"), "[]\n", "utf8");
+    fs.writeFileSync(path.join(legacyStorageDir, "comment-links.json"), "[]\n", "utf8");
+    fs.writeFileSync(path.join(legacyStorageDir, "runtime-state.json"), "[]\n", "utf8");
+
+    const result = migrateForgejoLegacyStorage({ storageDir, legacyStorageDir });
+
+    expect(result.migratedFiles).toEqual([
+      "item-links.json",
+      "comment-links.json",
+      "runtime-state.json",
+    ]);
+    expect(result.skippedFiles).toEqual([]);
+    expect(fs.readFileSync(path.join(storageDir, "item-links.json"), "utf8")).toBe("[]\n");
+    expect(fs.existsSync(path.join(legacyStorageDir, "item-links.json"))).toBe(false);
+    expect(fs.existsSync(legacyStorageDir)).toBe(false);
+  });
+
+  it("leaves unknown legacy files in place", () => {
+    const rootDir = createTempDir();
+    const legacyStorageDir = path.join(rootDir, "legacy");
+    const storageDir = path.join(rootDir, "state");
+    fs.mkdirSync(legacyStorageDir, { recursive: true });
+    fs.writeFileSync(path.join(legacyStorageDir, "item-links.json"), "[]\n", "utf8");
+    fs.writeFileSync(path.join(legacyStorageDir, "custom.json"), "{}\n", "utf8");
+
+    const result = migrateForgejoLegacyStorage({ storageDir, legacyStorageDir });
+
+    expect(result.migratedFiles).toEqual(["item-links.json"]);
+    expect(result.skippedFiles).toEqual(["comment-links.json", "runtime-state.json"]);
+    expect(fs.existsSync(path.join(storageDir, "item-links.json"))).toBe(true);
+    expect(fs.existsSync(path.join(legacyStorageDir, "custom.json"))).toBe(true);
+  });
+
+  it("does not overwrite existing destination files", () => {
+    const rootDir = createTempDir();
+    const legacyStorageDir = path.join(rootDir, "legacy");
+    const storageDir = path.join(rootDir, "state");
+    fs.mkdirSync(legacyStorageDir, { recursive: true });
+    fs.mkdirSync(storageDir, { recursive: true });
+    fs.writeFileSync(path.join(legacyStorageDir, "item-links.json"), "legacy\n", "utf8");
+    fs.writeFileSync(path.join(storageDir, "item-links.json"), "current\n", "utf8");
+
+    expect(() => migrateForgejoLegacyStorage({ storageDir, legacyStorageDir })).toThrow(
+      /destination already exists/
+    );
+    expect(fs.readFileSync(path.join(storageDir, "item-links.json"), "utf8")).toBe("current\n");
+    expect(fs.readFileSync(path.join(legacyStorageDir, "item-links.json"), "utf8")).toBe(
+      "legacy\n"
+    );
+  });
+
+  it("skips migration when the legacy directory is missing", () => {
+    const rootDir = createTempDir();
+    const result = migrateForgejoLegacyStorage({
+      storageDir: path.join(rootDir, "state"),
+      legacyStorageDir: path.join(rootDir, "missing"),
+    });
+
+    expect(result.migratedFiles).toEqual([]);
+    expect(result.skippedFiles).toEqual([
+      "item-links.json",
+      "comment-links.json",
+      "runtime-state.json",
+    ]);
+  });
+});

--- a/src/forgejo-storage.ts
+++ b/src/forgejo-storage.ts
@@ -1,0 +1,100 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export const FORGEJO_STORAGE_STATE_FILES = [
+  "item-links.json",
+  "comment-links.json",
+  "runtime-state.json",
+] as const;
+
+export interface ForgejoLegacyStorageMigrationOptions {
+  storageDir: string | null;
+  legacyStorageDir: string | null;
+}
+
+export interface ForgejoLegacyStorageMigrationResult {
+  migratedFiles: string[];
+  skippedFiles: string[];
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}
+
+function moveFileWithoutOverwrite(sourcePath: string, destinationPath: string): void {
+  if (fs.existsSync(destinationPath)) {
+    throw new Error(
+      `Cannot migrate Forgejo storage file ${sourcePath}: destination already exists at ${destinationPath}`
+    );
+  }
+
+  fs.mkdirSync(path.dirname(destinationPath), { recursive: true });
+
+  try {
+    fs.renameSync(sourcePath, destinationPath);
+  } catch (error) {
+    if (!isNodeError(error) || error.code !== "EXDEV") {
+      throw error;
+    }
+
+    fs.copyFileSync(sourcePath, destinationPath, fs.constants.COPYFILE_EXCL);
+    fs.unlinkSync(sourcePath);
+  }
+}
+
+export function migrateForgejoLegacyStorage(
+  options: ForgejoLegacyStorageMigrationOptions
+): ForgejoLegacyStorageMigrationResult {
+  const { storageDir, legacyStorageDir } = options;
+  if (
+    !storageDir ||
+    !legacyStorageDir ||
+    path.resolve(storageDir) === path.resolve(legacyStorageDir)
+  ) {
+    return { migratedFiles: [], skippedFiles: [...FORGEJO_STORAGE_STATE_FILES] };
+  }
+
+  if (!fs.existsSync(legacyStorageDir)) {
+    return { migratedFiles: [], skippedFiles: [...FORGEJO_STORAGE_STATE_FILES] };
+  }
+
+  const legacyStats = fs.statSync(legacyStorageDir);
+  if (!legacyStats.isDirectory()) {
+    throw new Error(
+      `Cannot migrate Forgejo storage from ${legacyStorageDir}: expected a directory`
+    );
+  }
+
+  const migratedFiles: string[] = [];
+  const skippedFiles: string[] = [];
+
+  for (const filename of FORGEJO_STORAGE_STATE_FILES) {
+    const sourcePath = path.join(legacyStorageDir, filename);
+    const destinationPath = path.join(storageDir, filename);
+
+    if (!fs.existsSync(sourcePath)) {
+      skippedFiles.push(filename);
+      continue;
+    }
+
+    const sourceStats = fs.statSync(sourcePath);
+    if (!sourceStats.isFile()) {
+      throw new Error(`Cannot migrate Forgejo storage file ${sourcePath}: expected a file`);
+    }
+
+    moveFileWithoutOverwrite(sourcePath, destinationPath);
+    migratedFiles.push(filename);
+  }
+
+  if (migratedFiles.length > 0) {
+    try {
+      fs.rmdirSync(legacyStorageDir);
+    } catch (error) {
+      if (!isNodeError(error) || (error.code !== "ENOTEMPTY" && error.code !== "ENOENT")) {
+        throw error;
+      }
+    }
+  }
+
+  return { migratedFiles, skippedFiles };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,8 +10,11 @@ export {
 export {
   ForgejoProviderConfigError,
   deriveForgejoApiBaseUrl,
+  expandForgejoHomePath,
+  getForgejoAppStateRoot,
   loadForgejoProviderSettings,
   normalizeForgejoBaseUrl,
+  resolveForgejoStorageDir,
   type ForgejoAuthType,
   type ForgejoProviderSettings,
 } from "@/forgejo-config";
@@ -76,6 +79,12 @@ export {
   type NormalizedForgejoStatus,
 } from "@/forgejo-fields";
 export { createHttpForgejoIssueClient } from "@/forgejo-http-client";
+export {
+  FORGEJO_STORAGE_STATE_FILES,
+  migrateForgejoLegacyStorage,
+  type ForgejoLegacyStorageMigrationOptions,
+  type ForgejoLegacyStorageMigrationResult,
+} from "@/forgejo-storage";
 export {
   createForgejoSyncLogger,
   formatForgejoLogEntry,


### PR DESCRIPTION
## Summary
- resolve relative Forgejo storage paths under a stable app-owned state root instead of daemon cwd
- add explicit legacyStorageDir migration for known Forgejo state files
- add a dry-run-first migration script for moving state on each affected machine
- update docs and smoke-test config to avoid cwd-relative durable state

## Verification
- npm run migrate:forgejo-storage -- --help
- dry-run and --write migration script smoke check with temp dirs
- npm run format
- npm run lint
- npm run typecheck
- npm test
- npm run build

Task: #task-61936e29