### PR TITLE
Fix Forgejo comment sync feedback loop

### DIFF
--- a/src/forgejo-comment-links.ts
+++ b/src/forgejo-comment-links.ts
@@ -3,6 +3,8 @@ import path from "node:path";
 
 import type { IntegrationBinding, NoteId, Task } from "@todu/core";
 
+export type ForgejoCommentOrigin = "forgejo" | "todu";
+
 export interface ForgejoCommentLink {
   bindingId: IntegrationBinding["id"];
   taskId: Task["id"];
@@ -11,6 +13,7 @@ export interface ForgejoCommentLink {
   forgejoCommentId: number;
   lastMirroredAt: string;
   lastMirroredBody?: string;
+  origin?: ForgejoCommentOrigin;
 }
 
 export interface ForgejoCommentLinkStore {

--- a/src/forgejo-comments.test.ts
+++ b/src/forgejo-comments.test.ts
@@ -64,7 +64,10 @@ describe("forgejo comments", () => {
   it("formats and strips attribution headers without nesting", () => {
     const body = formatAttributedBody(
       formatToduAttribution("bob", "2026-03-12T00:00:00.000Z"),
-      "Original body"
+      formatAttributedBody(
+        formatForgejoAttribution("alice", "2026-03-12T00:01:00.000Z"),
+        "Original body"
+      )
     );
 
     expect(stripAttribution(body)).toBe("Original body");
@@ -73,6 +76,11 @@ describe("forgejo comments", () => {
         formatAttributedBody(formatForgejoAttribution("alice", "2026-03-12T00:00:00.000Z"), "Body")
       )
     ).toBe(true);
+    expect(
+      stripAttribution(
+        "_Synced from Forgejo comment by @alice on 2026-05-08T11:05:36-05:00_\n\nOffset body"
+      )
+    ).toBe("Offset body");
   });
 
   it("pulls forgejo comments, strips existing attribution, and creates durable comment links", async () => {
@@ -96,7 +104,7 @@ describe("forgejo comments", () => {
         id: 11,
         issueNumber: 7,
         body: formatAttributedBody(
-          formatToduAttribution("bob", "2026-03-12T00:00:00.000Z"),
+          formatForgejoAttribution("bob", "2026-03-12T00:00:00.000Z"),
           "Plain comment body"
         ),
         author: "alice",
@@ -128,6 +136,136 @@ describe("forgejo comments", () => {
     expect(commentLinkStore.getByForgejoCommentId(binding.id, 11)).toMatchObject({
       noteId: "external:11",
       lastMirroredBody: "Plain comment body",
+    });
+  });
+
+  it("does not import todu-originated forgejo comments back into todu", async () => {
+    const issueClient = createInMemoryForgejoIssueClient();
+    const itemLinkStore = createInMemoryForgejoItemLinkStore();
+    const commentLinkStore = createInMemoryForgejoCommentLinkStore();
+
+    itemLinkStore.save(
+      createLinkFromTask({
+        binding,
+        taskId: createTaskId("task-1"),
+        baseUrl: target.baseUrl,
+        owner: target.owner,
+        repo: target.repo,
+        issueNumber: 7,
+      })
+    );
+    commentLinkStore.save({
+      bindingId: binding.id,
+      taskId: createTaskId("task-1"),
+      noteId: createNoteId("note-local"),
+      issueNumber: 7,
+      forgejoCommentId: 11,
+      lastMirroredAt: "2026-03-12T01:00:00.000Z",
+      lastMirroredBody: "Local body",
+    });
+
+    issueClient.seedComments(target, 7, [
+      {
+        id: 11,
+        issueNumber: 7,
+        body: formatAttributedBody(
+          formatToduAttribution("todu", "2026-03-12T01:00:00.000Z"),
+          "Local body"
+        ),
+        author: "erik",
+        createdAt: "2026-03-12T01:00:00.000Z",
+        updatedAt: "2026-03-12T02:00:00.000Z",
+      },
+    ]);
+
+    const result = await pullComments({
+      binding,
+      issueClient,
+      target,
+      itemLinkStore,
+      commentLinkStore,
+    });
+
+    expect(result.comments).toEqual([]);
+    expect(result.createdLinks).toEqual([]);
+    expect(commentLinkStore.getByForgejoCommentId(binding.id, 11)).toMatchObject({
+      noteId: createNoteId("note-local"),
+      lastMirroredAt: "2026-03-12T02:00:00.000Z",
+      lastMirroredBody: "Local body",
+    });
+  });
+
+  it("links unlinked local notes to existing todu-originated forgejo comments instead of creating duplicates", async () => {
+    const issueClient = createInMemoryForgejoIssueClient();
+    const itemLinkStore = createInMemoryForgejoItemLinkStore();
+    const commentLinkStore = createInMemoryForgejoCommentLinkStore();
+
+    issueClient.seedIssues(target, [
+      {
+        number: 7,
+        externalId: "https://forgejo.caradoc.com/erik/todu-forgejo-plugin-test#7",
+        title: "Issue",
+        state: "open",
+        labels: [],
+        assigneeActorIds: [],
+        assignees: [],
+        createdAt: "2026-03-12T00:00:00.000Z",
+        updatedAt: "2026-03-12T00:00:00.000Z",
+      },
+    ]);
+    issueClient.seedComments(target, 7, [
+      {
+        id: 21,
+        issueNumber: 7,
+        body: formatAttributedBody(
+          formatToduAttribution("todu", "2026-03-12T01:00:00.000Z"),
+          "Close-gate summary"
+        ),
+        author: "erik",
+        createdAt: "2026-03-12T01:00:00.000Z",
+        updatedAt: "2026-03-12T01:00:00.000Z",
+      },
+    ]);
+    itemLinkStore.save(
+      createLinkFromTask({
+        binding,
+        taskId: createTaskId("task-1"),
+        baseUrl: target.baseUrl,
+        owner: target.owner,
+        repo: target.repo,
+        issueNumber: 7,
+      })
+    );
+
+    const result = await pushComments({
+      binding,
+      issueClient,
+      target,
+      tasks: [
+        createTask([
+          {
+            localNoteId: createNoteId("note-local"),
+            body: "Close-gate summary",
+            createdAt: "2026-03-12T01:00:00.000Z",
+          },
+        ]),
+      ],
+      itemLinkStore,
+      commentLinkStore,
+    });
+
+    expect(result.createdComments).toEqual([]);
+    expect(result.updatedComments).toEqual([]);
+    expect(result.commentLinks).toEqual([
+      expect.objectContaining({
+        localNoteId: createNoteId("note-local"),
+        externalCommentId: "21",
+      }),
+    ]);
+    expect(issueClient.snapshotComments(target, 7)).toHaveLength(1);
+    expect(commentLinkStore.getByNoteId(binding.id, createNoteId("note-local"))).toMatchObject({
+      forgejoCommentId: 21,
+      lastMirroredBody: "Close-gate summary",
     });
   });
 
@@ -350,7 +488,7 @@ describe("forgejo comments", () => {
       commentLinkStore,
     });
 
-    expect(listCommentsCalls).toBe(0);
+    expect(listCommentsCalls).toBe(1);
     expect(result.updatedComments).toHaveLength(1);
     expect(result.updatedComments[0].id).toBe(21);
     expect(result.updatedComments[0].body).toBe(
@@ -618,6 +756,125 @@ describe("forgejo comments", () => {
     });
   });
 
+  it("skips unchanged Forgejo-origin notes by link metadata without requiring attribution text", async () => {
+    const issueClient = createInMemoryForgejoIssueClient();
+    const itemLinkStore = createInMemoryForgejoItemLinkStore();
+    const commentLinkStore = createInMemoryForgejoCommentLinkStore();
+
+    itemLinkStore.save(
+      createLinkFromTask({
+        binding,
+        taskId: createTaskId("task-1"),
+        baseUrl: target.baseUrl,
+        owner: target.owner,
+        repo: target.repo,
+        issueNumber: 7,
+      })
+    );
+    commentLinkStore.save({
+      bindingId: binding.id,
+      taskId: createTaskId("task-1"),
+      noteId: createNoteId("note-imported"),
+      issueNumber: 7,
+      forgejoCommentId: 21,
+      lastMirroredAt: "2026-03-12T05:00:00.000Z",
+      lastMirroredBody: "Imported body",
+      origin: "forgejo",
+    });
+
+    const result = await pushComments({
+      binding,
+      issueClient,
+      target,
+      tasks: [
+        createTask([
+          {
+            localNoteId: createNoteId("note-imported"),
+            body: "Imported body",
+            createdAt: "2026-03-12T00:00:00.000Z",
+          },
+        ]),
+      ],
+      itemLinkStore,
+      commentLinkStore,
+    });
+
+    expect(result.createdComments).toEqual([]);
+    expect(result.updatedComments).toEqual([]);
+    expect(result.commentLinks).toEqual([]);
+  });
+
+  it("reconciles imported note tag conflicts without returning a conflicting push link", async () => {
+    const issueClient = createInMemoryForgejoIssueClient();
+    const itemLinkStore = createInMemoryForgejoItemLinkStore();
+    const commentLinkStore = createInMemoryForgejoCommentLinkStore();
+
+    issueClient.seedIssues(target, [
+      {
+        number: 7,
+        externalId: "https://forgejo.caradoc.com/erik/todu-forgejo-plugin-test#7",
+        title: "Issue",
+        state: "open",
+        labels: [],
+        assigneeActorIds: [],
+        assignees: [],
+        createdAt: "2026-03-12T00:00:00.000Z",
+        updatedAt: "2026-03-12T00:00:00.000Z",
+      },
+    ]);
+
+    itemLinkStore.save(
+      createLinkFromTask({
+        binding,
+        taskId: createTaskId("task-1"),
+        baseUrl: target.baseUrl,
+        owner: target.owner,
+        repo: target.repo,
+        issueNumber: 7,
+      })
+    );
+    commentLinkStore.save({
+      bindingId: binding.id,
+      taskId: createTaskId("task-1"),
+      noteId: createNoteId("note-imported"),
+      issueNumber: 7,
+      forgejoCommentId: 1383,
+      lastMirroredAt: "2026-03-12T05:00:00.000Z",
+      lastMirroredBody: "Imported body",
+    });
+
+    const result = await pushComments({
+      binding,
+      issueClient,
+      target,
+      tasks: [
+        createTask([
+          {
+            localNoteId: createNoteId("note-imported"),
+            body: formatAttributedBody(
+              formatForgejoAttribution("alice", "2026-03-12T00:00:00.000Z"),
+              "Imported body"
+            ),
+            createdAt: "2026-03-12T00:00:00.000Z",
+          },
+        ]),
+      ],
+      itemLinkStore,
+      commentLinkStore,
+      loadTaskNotes: async () => [
+        { id: String(createNoteId("note-imported")), tags: ["sync:externalId:1370"] },
+      ],
+    });
+
+    expect(result.createdComments).toEqual([]);
+    expect(result.updatedComments).toEqual([]);
+    expect(result.commentLinks).toEqual([]);
+    expect(commentLinkStore.getByNoteId(binding.id, createNoteId("note-imported"))).toMatchObject({
+      forgejoCommentId: 1370,
+      lastMirroredBody: "Imported body",
+    });
+  });
+
   it("reconciles legacy imported comment links to real local note ids during push", async () => {
     const issueClient = createInMemoryForgejoIssueClient();
     const itemLinkStore = createInMemoryForgejoItemLinkStore();
@@ -690,9 +947,7 @@ describe("forgejo comments", () => {
 
     expect(result.updatedComments).toHaveLength(0);
     expect(result.createdComments).toHaveLength(0);
-    expect(result.commentLinks).toEqual([
-      expect.objectContaining({ localNoteId: createNoteId("note-real"), externalCommentId: "21" }),
-    ]);
+    expect(result.commentLinks).toEqual([]);
     expect(commentLinkStore.getByNoteId(binding.id, createNoteId("note-real"))).toMatchObject({
       taskId: createTaskId("task-1"),
       forgejoCommentId: 21,
@@ -783,7 +1038,7 @@ describe("forgejo comments", () => {
 
     expect(result.updatedComments).toHaveLength(0);
     expect(result.createdComments).toHaveLength(0);
-    expect(result.commentLinks).toHaveLength(1);
+    expect(result.commentLinks).toHaveLength(0);
     expect(commentLinkStore.getByNoteId(binding.id, createNoteId("external:21"))).toMatchObject({
       lastMirroredBody: "Remote changed body",
     });

--- a/src/forgejo-comments.ts
+++ b/src/forgejo-comments.ts
@@ -13,12 +13,16 @@ import {
   type ForgejoComment,
   type ForgejoIssueClient,
 } from "@/forgejo-client";
-import type { ForgejoCommentLink, ForgejoCommentLinkStore } from "@/forgejo-comment-links";
+import type {
+  ForgejoCommentLink,
+  ForgejoCommentLinkStore,
+  ForgejoCommentOrigin,
+} from "@/forgejo-comment-links";
 import type { ForgejoItemLink, ForgejoItemLinkStore } from "@/forgejo-links";
 
 const FORGEJO_ATTRIBUTION_PREFIX = "_Synced from Forgejo comment by @";
 const TODU_ATTRIBUTION_PREFIX = "_Synced from todu comment by @";
-const ATTRIBUTION_SUFFIX_PATTERN = / on \d{4}-\d{2}-\d{2}T[\d:.]+Z_$/;
+const ATTRIBUTION_SUFFIX_PATTERN = / on \d{4}-\d{2}-\d{2}T[\d:.]+(?:Z|[+-]\d{2}:\d{2})_$/;
 const IMPORTED_COMMENT_LINK_PREFIX = "external:";
 const SYNC_EXTERNAL_ID_TAG_PREFIX = "sync:externalId:";
 const TODU_COMMENT_AUTHOR = "todu";
@@ -45,28 +49,38 @@ export function formatAttributedBody(attribution: string, body: string): string 
 }
 
 export function stripAttribution(body: string): string {
-  const lines = body.split("\n");
-  if (lines.length < 1) {
-    return body;
-  }
+  let stripped = body;
 
-  const firstLine = lines[0];
-  if (
-    (firstLine.startsWith(FORGEJO_ATTRIBUTION_PREFIX) ||
-      firstLine.startsWith(TODU_ATTRIBUTION_PREFIX)) &&
-    ATTRIBUTION_SUFFIX_PATTERN.test(firstLine)
-  ) {
+  while (true) {
+    const lines = stripped.split("\n");
+    const firstLine = lines[0];
+    if (!isAttributionLine(firstLine)) {
+      return stripped;
+    }
+
     const remaining = lines.slice(1).join("\n");
-    return remaining.startsWith("\n") ? remaining.slice(1) : remaining;
+    stripped = remaining.startsWith("\n") ? remaining.slice(1) : remaining;
   }
-
-  return body;
 }
 
 export function hasForgejoAttribution(body: string): boolean {
+  return hasAttributionPrefix(body, FORGEJO_ATTRIBUTION_PREFIX);
+}
+
+function hasToduAttribution(body: string): boolean {
+  return hasAttributionPrefix(body, TODU_ATTRIBUTION_PREFIX);
+}
+
+function hasAttributionPrefix(body: string, prefix: string): boolean {
   const firstLine = body.split("\n")[0];
+  return firstLine.startsWith(prefix) && ATTRIBUTION_SUFFIX_PATTERN.test(firstLine);
+}
+
+function isAttributionLine(line: string | undefined): boolean {
   return (
-    firstLine.startsWith(FORGEJO_ATTRIBUTION_PREFIX) && ATTRIBUTION_SUFFIX_PATTERN.test(firstLine)
+    line !== undefined &&
+    (line.startsWith(FORGEJO_ATTRIBUTION_PREFIX) || line.startsWith(TODU_ATTRIBUTION_PREFIX)) &&
+    ATTRIBUTION_SUFFIX_PATTERN.test(line)
   );
 }
 
@@ -81,6 +95,39 @@ function isLegacyImportedCommentLinkNoteId(noteId: NoteId): boolean {
 function getImportedForgejoSyncExternalId(note: Pick<ForgejoPushNote, "tags">): string | null {
   const syncTag = note.tags.find((tag) => tag.startsWith(SYNC_EXTERNAL_ID_TAG_PREFIX));
   return syncTag ? syncTag.slice(SYNC_EXTERNAL_ID_TAG_PREFIX.length) : null;
+}
+
+function getCommentLinkOrigin(link: ForgejoCommentLink): ForgejoCommentOrigin {
+  if (link.origin) {
+    return link.origin;
+  }
+
+  return isLegacyImportedCommentLinkNoteId(link.noteId) ? "forgejo" : "todu";
+}
+
+function inferReconciledCommentOrigin(input: {
+  canonicalLink: ForgejoCommentLink | null;
+  existingLink: ForgejoCommentLink | null;
+  note: ForgejoPushNote;
+}): ForgejoCommentOrigin {
+  if (input.canonicalLink) {
+    return getCommentLinkOrigin(input.canonicalLink);
+  }
+
+  if (input.existingLink) {
+    return getCommentLinkOrigin(input.existingLink);
+  }
+
+  return hasForgejoAttribution(input.note.content) ? "forgejo" : "todu";
+}
+
+function shouldSkipUnchangedImportedNote(note: ForgejoPushNote, link: ForgejoCommentLink): boolean {
+  const localBody = stripAttribution(note.content);
+  if (localBody !== link.lastMirroredBody) {
+    return false;
+  }
+
+  return getCommentLinkOrigin(link) === "forgejo" || hasForgejoAttribution(note.content);
 }
 
 export interface PullCommentsResult {
@@ -138,6 +185,25 @@ export async function pullComments(input: {
 
     for (const forgejoComment of forgejoComments) {
       const strippedBody = stripAttribution(forgejoComment.body);
+      const existingLink = input.commentLinkStore.getByForgejoCommentId(
+        input.binding.id,
+        forgejoComment.id
+      );
+
+      if (existingLink && getCommentLinkOrigin(existingLink) === "todu") {
+        input.commentLinkStore.save({
+          ...existingLink,
+          lastMirroredAt: forgejoComment.updatedAt ?? forgejoComment.createdAt,
+          lastMirroredBody: strippedBody,
+          origin: "todu",
+        });
+        continue;
+      }
+
+      if (!existingLink && hasToduAttribution(forgejoComment.body)) {
+        continue;
+      }
+
       const authorDisplayName = getForgejoActorDisplayName(forgejoComment.author);
       const normalizedAuthor = createForgejoActorRef(forgejoComment.author);
 
@@ -154,11 +220,6 @@ export async function pullComments(input: {
         raw: forgejoComment,
       });
 
-      const existingLink = input.commentLinkStore.getByForgejoCommentId(
-        input.binding.id,
-        forgejoComment.id
-      );
-
       if (!existingLink) {
         const newLink: ForgejoCommentLink = {
           bindingId: input.binding.id,
@@ -168,6 +229,7 @@ export async function pullComments(input: {
           forgejoCommentId: forgejoComment.id,
           lastMirroredAt: forgejoComment.updatedAt ?? forgejoComment.createdAt,
           lastMirroredBody: strippedBody,
+          origin: "forgejo",
         };
 
         input.commentLinkStore.save(newLink);
@@ -179,6 +241,7 @@ export async function pullComments(input: {
         ...existingLink,
         lastMirroredAt: forgejoComment.updatedAt ?? forgejoComment.createdAt,
         lastMirroredBody: strippedBody,
+        origin: getCommentLinkOrigin(existingLink),
       });
     }
   }
@@ -265,6 +328,10 @@ export async function pushComments(input: {
       }
 
       if (existingLink) {
+        if (shouldSkipUnchangedImportedNote(note, existingLink)) {
+          continue;
+        }
+
         const updated = await updateForgejoCommentIfNeeded(
           input,
           note,
@@ -275,6 +342,12 @@ export async function pushComments(input: {
           createPushCommentLink(note.id, itemLink.taskId, existingLink.forgejoCommentId, updated)
         );
       } else {
+        const matched = await linkExistingForgejoCommentForNote(input, note, itemLink);
+        if (matched) {
+          commentLinks.push(createPushCommentLink(note.id, itemLink.taskId, matched.id, matched));
+          continue;
+        }
+
         const created = await createForgejoCommentFromNote(input, note, itemLink, createdComments);
         commentLinks.push(createPushCommentLink(note.id, itemLink.taskId, created.id, created));
       }
@@ -329,6 +402,7 @@ function resolveCommentLinkForPush(input: {
       canonicalLink?.lastMirroredBody ??
       existingLink?.lastMirroredBody ??
       stripAttribution(input.note.content),
+    origin: inferReconciledCommentOrigin({ canonicalLink, existingLink, note: input.note }),
   };
 
   if (existingLink && existingLink.forgejoCommentId !== forgejoCommentId) {
@@ -370,6 +444,7 @@ function reconcileLegacyCommentLinks(
       ...existingLink,
       taskId: itemLink.taskId,
       noteId: resolvedNoteId,
+      origin: getCommentLinkOrigin(existingLink),
     });
   }
 }
@@ -446,9 +521,53 @@ async function updateForgejoCommentIfNeeded(
     ...existingLink,
     lastMirroredAt: updatedComment.updatedAt ?? updatedComment.createdAt,
     lastMirroredBody: localBody,
+    origin: getCommentLinkOrigin(existingLink),
   });
 
   return updatedComment;
+}
+
+async function linkExistingForgejoCommentForNote(
+  input: {
+    binding: IntegrationBinding;
+    issueClient: ForgejoIssueClient;
+    target: {
+      baseUrl: string;
+      apiBaseUrl: string;
+      owner: string;
+      repo: string;
+    };
+    commentLinkStore: ForgejoCommentLinkStore;
+  },
+  note: ForgejoPushNote,
+  itemLink: ForgejoItemLink
+): Promise<ForgejoComment | null> {
+  const localBody = stripAttribution(note.content);
+  const forgejoComments = await input.issueClient.listComments(input.target, itemLink.issueNumber);
+  const matchingComments = forgejoComments.filter(
+    (comment) =>
+      hasToduAttribution(comment.body) &&
+      stripAttribution(comment.body) === localBody &&
+      !input.commentLinkStore.getByForgejoCommentId(input.binding.id, comment.id)
+  );
+
+  if (matchingComments.length === 0) {
+    return null;
+  }
+
+  const matchedComment = matchingComments.sort((left, right) => left.id - right.id)[0];
+  input.commentLinkStore.save({
+    bindingId: input.binding.id,
+    taskId: itemLink.taskId,
+    noteId: note.id,
+    issueNumber: itemLink.issueNumber,
+    forgejoCommentId: matchedComment.id,
+    lastMirroredAt: matchedComment.updatedAt ?? matchedComment.createdAt,
+    lastMirroredBody: localBody,
+    origin: "todu",
+  });
+
+  return matchedComment;
 }
 
 async function createForgejoCommentFromNote(
@@ -489,6 +608,7 @@ async function createForgejoCommentFromNote(
     forgejoCommentId: createdComment.id,
     lastMirroredAt: createdComment.updatedAt ?? createdComment.createdAt,
     lastMirroredBody: localBody,
+    origin: "todu",
   });
 
   return createdComment;

--- a/src/forgejo-provider-hardening.test.ts
+++ b/src/forgejo-provider-hardening.test.ts
@@ -392,13 +392,7 @@ describe("provider error classification coverage", () => {
       project
     );
 
-    expect(pushResult.commentLinks).toEqual([
-      expect.objectContaining({
-        localNoteId: createNoteId("note-real"),
-        externalCommentId: "21",
-        externalTaskId: createTaskId("task-1"),
-      }),
-    ]);
+    expect(pushResult.commentLinks).toEqual([]);
     expect(
       commentLinkStore.getByNoteId(createBinding().id, createNoteId("note-real"))
     ).toMatchObject({

--- a/src/forgejo-provider.test.ts
+++ b/src/forgejo-provider.test.ts
@@ -12,6 +12,7 @@ import {
 
 import { FORGEJO_PROVIDER_NAME, FORGEJO_REPOSITORY_TARGET_KIND } from "@/forgejo-binding";
 import { createInMemoryForgejoIssueClient } from "@/forgejo-client";
+import { formatAttributedBody, formatToduAttribution } from "@/forgejo-comments";
 import { createForgejoSyncLogger } from "@/forgejo-logger";
 import { createInMemoryForgejoItemLinkStore } from "@/forgejo-links";
 import { createForgejoLoopPreventionStore } from "@/forgejo-loop-prevention";
@@ -351,6 +352,151 @@ describe("forgejo provider runtime integration", () => {
     });
     expect(result.comments?.[0].body).toContain("Imported comment body");
     expect(provider.getState().commentLinks).toHaveLength(1);
+  });
+
+  it("keeps bidirectional comment sync idempotent across push and pull cycles", async () => {
+    const issueClient = createInMemoryForgejoIssueClient();
+    issueClient.seedIssues(target, [
+      {
+        number: 7,
+        externalId: "https://code.example.com/acme/roadmap#7",
+        title: "Issue seven",
+        state: "open",
+        labels: ["status:active"],
+        assignees: [],
+        createdAt: "2026-03-12T00:00:00.000Z",
+        updatedAt: "2026-03-12T00:00:00.000Z",
+      },
+    ]);
+
+    const provider = createForgejoSyncProvider({
+      issueClient,
+      linkStore: createInMemoryForgejoItemLinkStore(),
+      runtimeStore: createInMemoryForgejoBindingRuntimeStore(),
+    });
+    await provider.initialize({
+      settings: {
+        baseUrl: target.baseUrl,
+        token: "secret-token",
+      },
+    });
+
+    await provider.pull(createBinding(), project);
+    const firstPush = await provider.push(
+      createBinding(),
+      [
+        createExportedTask({
+          localTaskId: createTaskId("task-1"),
+          externalId: "https://code.example.com/acme/roadmap#7",
+          comments: [
+            {
+              localNoteId: "note-1" as never,
+              body: "Close-gate summary",
+              createdAt: "2026-03-12T01:00:00.000Z",
+            },
+          ],
+        }),
+      ],
+      project
+    );
+    const pullAfterPush = await provider.pull(createBinding(), project);
+    const secondPush = await provider.push(
+      createBinding(),
+      [
+        createExportedTask({
+          localTaskId: createTaskId("task-1"),
+          externalId: "https://code.example.com/acme/roadmap#7",
+          comments: [
+            {
+              localNoteId: "note-1" as never,
+              body: "Close-gate summary",
+              createdAt: "2026-03-12T01:00:00.000Z",
+            },
+          ],
+        }),
+      ],
+      project
+    );
+
+    expect(firstPush.commentLinks).toEqual([
+      expect.objectContaining({ localNoteId: "note-1", externalCommentId: "1" }),
+    ]);
+    expect(pullAfterPush.comments).toEqual([]);
+    expect(secondPush.commentLinks).toEqual([
+      expect.objectContaining({ localNoteId: "note-1", externalCommentId: "1" }),
+    ]);
+    expect(issueClient.snapshotComments(target, 7)).toHaveLength(1);
+    expect(provider.getState().commentLinks).toEqual([
+      expect.objectContaining({ noteId: "note-1", forgejoCommentId: 1 }),
+    ]);
+  });
+
+  it("relinks existing todu-attributed remote comments when a local comment link is missing", async () => {
+    const issueClient = createInMemoryForgejoIssueClient();
+    issueClient.seedIssues(target, [
+      {
+        number: 7,
+        externalId: "https://code.example.com/acme/roadmap#7",
+        title: "Issue seven",
+        state: "open",
+        labels: ["status:active"],
+        assignees: [],
+        createdAt: "2026-03-12T00:00:00.000Z",
+        updatedAt: "2026-03-12T00:00:00.000Z",
+      },
+    ]);
+    issueClient.seedComments(target, 7, [
+      {
+        id: 11,
+        issueNumber: 7,
+        body: formatAttributedBody(
+          formatToduAttribution("todu", "2026-03-12T01:00:00.000Z"),
+          "Close-gate summary"
+        ),
+        author: "erik",
+        createdAt: "2026-03-12T01:00:00.000Z",
+        updatedAt: "2026-03-12T01:00:00.000Z",
+      },
+    ]);
+
+    const provider = createForgejoSyncProvider({
+      issueClient,
+      linkStore: createInMemoryForgejoItemLinkStore(),
+      runtimeStore: createInMemoryForgejoBindingRuntimeStore(),
+    });
+    await provider.initialize({
+      settings: {
+        baseUrl: target.baseUrl,
+        token: "secret-token",
+      },
+    });
+
+    await provider.pull(createBinding(), project);
+    const pushResult = await provider.push(
+      createBinding(),
+      [
+        createExportedTask({
+          localTaskId: createTaskId("task-1"),
+          externalId: "https://code.example.com/acme/roadmap#7",
+          comments: [
+            {
+              localNoteId: "note-1" as never,
+              body: "Close-gate summary",
+              createdAt: "2026-03-12T01:00:00.000Z",
+            },
+          ],
+        }),
+      ],
+      project
+    );
+
+    expect(pushResult.commentLinks).toEqual([
+      expect.objectContaining({ localNoteId: "note-1", externalCommentId: "11" }),
+    ]);
+    expect(issueClient.snapshotComments(target, 7)).toHaveLength(1);
+    expect(provider.getState().commentLinks).toEqual([
+      expect.objectContaining({ noteId: "note-1", forgejoCommentId: 11 }),
+    ]);
   });
 
   it("checks all linked issues for incremental comments", async () => {


### PR DESCRIPTION
## Summary
- store comment-link origin metadata (`forgejo` vs `todu`) and use it as the primary loop-prevention guard
- strip nested Forgejo/todu attribution headers, including offset timestamps, for legacy cleanup
- skip pulling known Todu-originated Forgejo comments back into Todu
- relink unlinked local notes to existing Todu-attributed Forgejo comments as a legacy recovery fallback instead of creating duplicates
- avoid returning push links for unchanged imported notes that could conflict with existing sync tags

## Verification
- ./scripts/pre-pr.sh

Task: #task-d25fb7fb
