### PR TITLE
Fix Forgejo comment pagination loop

### DIFF
--- a/src/forgejo-http-client.test.ts
+++ b/src/forgejo-http-client.test.ts
@@ -1,10 +1,28 @@
 import { createHttpForgejoIssueClient } from "@/forgejo-http-client";
 
+const target = {
+  baseUrl: "https://forge.caradoc.com",
+  apiBaseUrl: "https://forge.caradoc.com/api/v1",
+  owner: "acme",
+  repo: "roadmap",
+};
+
 function createJsonResponse(body: unknown): Response {
   return new Response(JSON.stringify(body), {
     status: 200,
     headers: { "Content-Type": "application/json" },
   });
+}
+
+function createApiComment(id: number) {
+  return {
+    id,
+    body: `Comment ${id}`,
+    user: { id: id + 1000, login: `user-${id}` },
+    html_url: `https://forge.caradoc.com/acme/roadmap/issues/45#comment-${id}`,
+    created_at: "2026-05-12T00:00:00.000Z",
+    updated_at: "2026-05-12T00:00:00.000Z",
+  };
 }
 
 describe("forgejo http client", () => {
@@ -25,10 +43,7 @@ describe("forgejo http client", () => {
     });
 
     await client.listIssues({
-      baseUrl: "https://forge.caradoc.com",
-      apiBaseUrl: "https://forge.caradoc.com/api/v1",
-      owner: "acme",
-      repo: "roadmap",
+      ...target,
       token: "instance-token",
       authType: "bearer",
     });
@@ -39,5 +54,65 @@ describe("forgejo http client", () => {
         authorization: "Bearer instance-token",
       },
     ]);
+  });
+
+  it("stops comment pagination when a repeated page is returned", async () => {
+    const requests: string[] = [];
+    const page = Array.from({ length: 100 }, (_, index) => createApiComment(index + 1));
+    const fetchImpl: typeof fetch = async (url) => {
+      requests.push(String(url));
+      if (requests.length > 2) {
+        throw new Error("pagination should have stopped after the repeated page");
+      }
+
+      return createJsonResponse(page);
+    };
+
+    const client = createHttpForgejoIssueClient("token", { fetchImpl });
+
+    const comments = await client.listComments(target, 45);
+
+    expect(comments).toHaveLength(100);
+    expect(comments.map((comment) => comment.id)).toEqual(page.map((comment) => comment.id));
+    expect(requests).toEqual([
+      "https://forge.caradoc.com/api/v1/repos/acme/roadmap/issues/45/comments?limit=100&page=1",
+      "https://forge.caradoc.com/api/v1/repos/acme/roadmap/issues/45/comments?limit=100&page=2",
+    ]);
+  });
+
+  it("deduplicates comments by id when an oversized non-paginated response repeats", async () => {
+    const page = Array.from({ length: 125 }, (_, index) => createApiComment(index + 1));
+    const requests: string[] = [];
+    const fetchImpl: typeof fetch = async (url) => {
+      requests.push(String(url));
+      if (requests.length > 2) {
+        throw new Error("pagination should have stopped after the oversized repeated page");
+      }
+
+      return createJsonResponse(page);
+    };
+
+    const client = createHttpForgejoIssueClient("token", { fetchImpl });
+
+    const comments = await client.listComments(target, 45);
+
+    expect(comments).toHaveLength(125);
+    expect(new Set(comments.map((comment) => comment.id))).toHaveLength(125);
+    expect(requests).toHaveLength(2);
+  });
+
+  it("deduplicates comments by id across partially overlapping pages", async () => {
+    const pages = [
+      Array.from({ length: 100 }, (_, index) => createApiComment(index + 1)),
+      [createApiComment(100), createApiComment(101)],
+    ];
+    const fetchImpl: typeof fetch = async () => createJsonResponse(pages.shift() ?? []);
+    const client = createHttpForgejoIssueClient("token", { fetchImpl });
+
+    const comments = await client.listComments(target, 45);
+
+    expect(comments.map((comment) => comment.id)).toEqual(
+      Array.from({ length: 101 }, (_, index) => index + 1)
+    );
   });
 });

--- a/src/forgejo-http-client.ts
+++ b/src/forgejo-http-client.ts
@@ -48,6 +48,10 @@ interface ForgejoApiComment {
   updated_at: string;
 }
 
+interface ListAllPagesOptions<T> {
+  itemKey?: (item: T) => number | string;
+}
+
 function normalizeLabels(labels: ForgejoApiIssue["labels"]): string[] {
   return labels.map((label) => (typeof label === "string" ? label : label.name));
 }
@@ -125,7 +129,8 @@ export function createHttpForgejoIssueClient(
 
     const rawLabels = await listAllPages<ForgejoApiLabel>(
       target,
-      `/repos/${target.owner}/${target.repo}/labels`
+      `/repos/${target.owner}/${target.repo}/labels`,
+      { itemKey: (label) => label.id }
     );
 
     const mapping = new Map<string, number>();
@@ -194,8 +199,14 @@ export function createHttpForgejoIssueClient(
     return (await response.json()) as T;
   };
 
-  const listAllPages = async <T>(target: ForgejoRepositoryTarget, path: string): Promise<T[]> => {
+  const listAllPages = async <T>(
+    target: ForgejoRepositoryTarget,
+    path: string,
+    options: ListAllPagesOptions<T> = {}
+  ): Promise<T[]> => {
     const results: T[] = [];
+    const seenItemKeys = new Set<string>();
+    const seenPageSignatures = new Set<string>();
     let page = 1;
     const limit = 100;
 
@@ -206,9 +217,35 @@ export function createHttpForgejoIssueClient(
         "GET",
         `${path}${separator}limit=${limit}&page=${page}`
       );
-      results.push(...items);
+      const itemKey = options.itemKey;
+      const pageSignature = itemKey
+        ? items.map((item) => String(itemKey(item))).join("\0")
+        : JSON.stringify(items);
 
-      if (items.length < limit) {
+      if (seenPageSignatures.has(pageSignature)) {
+        break;
+      }
+      seenPageSignatures.add(pageSignature);
+
+      let addedCount = 0;
+      for (const item of items) {
+        if (!itemKey) {
+          results.push(item);
+          addedCount += 1;
+          continue;
+        }
+
+        const key = String(itemKey(item));
+        if (seenItemKeys.has(key)) {
+          continue;
+        }
+
+        seenItemKeys.add(key);
+        results.push(item);
+        addedCount += 1;
+      }
+
+      if (items.length < limit || (itemKey && items.length > 0 && addedCount === 0)) {
         break;
       }
 
@@ -228,7 +265,9 @@ export function createHttpForgejoIssueClient(
         path += `&since=${encodeURIComponent(options.since)}`;
       }
 
-      const rawIssues = await listAllPages<ForgejoApiIssue>(target, path);
+      const rawIssues = await listAllPages<ForgejoApiIssue>(target, path, {
+        itemKey: (issue) => issue.number,
+      });
       return rawIssues.map((rawIssue) => mapApiIssue(target, rawIssue));
     },
 
@@ -306,7 +345,8 @@ export function createHttpForgejoIssueClient(
     async listLabels(target: ForgejoRepositoryTarget): Promise<string[]> {
       const rawLabels = await listAllPages<ForgejoApiLabel>(
         target,
-        `/repos/${target.owner}/${target.repo}/labels`
+        `/repos/${target.owner}/${target.repo}/labels`,
+        { itemKey: (label) => label.id }
       );
       return rawLabels.map((label) => label.name);
     },
@@ -334,7 +374,9 @@ export function createHttpForgejoIssueClient(
         path += `?since=${encodeURIComponent(options.since)}`;
       }
 
-      const rawComments = await listAllPages<ForgejoApiComment>(target, path);
+      const rawComments = await listAllPages<ForgejoApiComment>(target, path, {
+        itemKey: (comment) => comment.id,
+      });
       return rawComments.map((rawComment) => mapApiComment(target, issueNumber, rawComment));
     },
 


### PR DESCRIPTION
## Summary

- stop Forgejo pagination when a repeated page/signature is observed
- deduplicate paginated results with stable remote IDs, including comments by comment ID
- add regression coverage for repeated and oversized non-paginated comment responses

## Verification

- npm run format
- npm run lint
- npm run typecheck
- npm test
- ./scripts/pre-pr.sh

Task: #task-4595e7b3