### PR TITLE
Record Forgejo partial pull progress

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -505,6 +505,10 @@ Comments no longer remain the exception. Mirrored comment deletes do not propaga
 - interval configurable in plugin config
 - each binding keeps independent cursor and retry state
 
+### Cursor and failure checkpoint semantics
+
+The runtime `cursor` is the provider's safe remote-read checkpoint. A fully successful pull or push records a new cursor, clears retry state, and clears any pending comment issue list. If a pull finishes issue discovery/link updates but fails while reading comments, the provider records a partial-progress checkpoint with `lastFailurePhase = pull:comments`, advances `cursor` to that safe issue checkpoint, and stores `pendingCommentIssueNumbers` for the touched issues whose comments still need retry. The next retry lists issues from the advanced cursor while still fetching comments for the pending issues using the previous successful comment checkpoint, so old issue updates are not reprocessed indefinitely and missed comments are not silently skipped. If a failure happens before a safe checkpoint is known, the cursor does not advance. Runtime diagnostics (`lastError`, `lastProgressAt`, `lastFailurePhase`, `lastFailureCursor`, and `pendingCommentIssueNumbers`) explain why a cursor did or did not move.
+
 ## Retry
 
 Reuse the GitHub plugin's per-binding exponential backoff model:

--- a/src/forgejo-provider.test.ts
+++ b/src/forgejo-provider.test.ts
@@ -17,7 +17,10 @@ import { createForgejoSyncLogger } from "@/forgejo-logger";
 import { createInMemoryForgejoItemLinkStore } from "@/forgejo-links";
 import { createForgejoLoopPreventionStore } from "@/forgejo-loop-prevention";
 import { classifyForgejoSyncError, createForgejoSyncProvider } from "@/forgejo-provider";
-import { createInMemoryForgejoBindingRuntimeStore } from "@/forgejo-runtime";
+import {
+  createInitialForgejoRuntimeState,
+  createInMemoryForgejoBindingRuntimeStore,
+} from "@/forgejo-runtime";
 
 function createBinding(overrides: Partial<IntegrationBinding> = {}): IntegrationBinding {
   return {
@@ -676,6 +679,112 @@ describe("forgejo provider runtime integration", () => {
     expect(state!.retryAttempt).toBe(1);
     expect(state!.lastError).toContain("rate limited");
     expect(state!.nextRetryAt).not.toBeNull();
+  });
+
+  it("advances safe pull progress and retries pending comments after a comment failure", async () => {
+    const issueClient = createInMemoryForgejoIssueClient();
+    issueClient.seedIssues(target, [
+      {
+        number: 7,
+        externalId: "https://code.example.com/acme/roadmap#7",
+        title: "Issue seven updated",
+        state: "open",
+        labels: ["status:active"],
+        assignees: [],
+        createdAt: "2026-03-12T00:00:00.000Z",
+        updatedAt: "2026-03-12T00:01:00.000Z",
+      },
+    ]);
+    issueClient.seedComments(target, 7, [
+      {
+        id: 11,
+        issueNumber: 7,
+        body: "Comment seven",
+        author: "alice",
+        createdAt: "2026-03-12T00:01:30.000Z",
+        updatedAt: "2026-03-12T00:01:30.000Z",
+      },
+    ]);
+
+    const binding = createBinding();
+    const linkStore = createInMemoryForgejoItemLinkStore();
+    linkStore.save({
+      bindingId: binding.id,
+      taskId: createTaskId("task-7"),
+      issueNumber: 7,
+      externalId: "https://code.example.com/acme/roadmap#7",
+      lastMirroredAt: "2026-03-12T00:00:00.000Z",
+    });
+
+    const runtimeStore = createInMemoryForgejoBindingRuntimeStore();
+    runtimeStore.save({
+      ...createInitialForgejoRuntimeState(binding.id),
+      cursor: "2026-03-12T00:00:00.000Z",
+      lastSuccessAt: "2026-03-12T00:00:00.000Z",
+    });
+
+    const listIssueSinceValues: Array<string | undefined> = [];
+    const originalListIssues = issueClient.listIssues.bind(issueClient);
+    issueClient.listIssues = async (bindingTarget, options) => {
+      listIssueSinceValues.push(options?.since);
+      return originalListIssues(bindingTarget, options);
+    };
+
+    const listCommentsCalls: number[] = [];
+    const originalListComments = issueClient.listComments.bind(issueClient);
+    let failComments = true;
+    issueClient.listComments = async (bindingTarget, issueNumber, options) => {
+      listCommentsCalls.push(issueNumber);
+      if (failComments) {
+        throw new Error("Forgejo API GET /comments failed: 500 unavailable");
+      }
+
+      return originalListComments(bindingTarget, issueNumber, options);
+    };
+
+    const provider = createForgejoSyncProvider({
+      issueClient,
+      linkStore,
+      runtimeStore,
+      retryConfig: { initialSeconds: 0, maxSeconds: 0 },
+    });
+
+    await provider.initialize({
+      settings: {
+        baseUrl: target.baseUrl,
+        token: "secret-token",
+      },
+    });
+
+    await expect(provider.pull(binding, project)).rejects.toThrow("500 unavailable");
+
+    const failedState = runtimeStore.get(binding.id);
+    expect(failedState).toMatchObject({
+      lastFailurePhase: "pull:comments",
+      pendingCommentIssueNumbers: [7],
+    });
+    expect(failedState?.cursor).not.toBe("2026-03-12T00:00:00.000Z");
+    expect(Date.parse(failedState!.cursor!)).toBeGreaterThan(
+      Date.parse("2026-03-12T00:01:00.000Z")
+    );
+
+    failComments = false;
+    const retryResult = await provider.pull(binding, project);
+
+    expect(listIssueSinceValues.at(-1)).toBe(failedState?.cursor);
+    expect(retryResult.tasks).toEqual([]);
+    expect(retryResult.comments).toHaveLength(1);
+    expect(runtimeStore.get(binding.id)).toMatchObject({
+      lastError: null,
+      lastFailurePhase: null,
+      pendingCommentIssueNumbers: [],
+    });
+
+    const commentCallsAfterRetry = listCommentsCalls.length;
+    const finalResult = await provider.pull(binding, project);
+
+    expect(finalResult.comments).toEqual([]);
+    expect(listCommentsCalls).toHaveLength(commentCallsAfterRetry);
   });
 
   it("skips pull when retry backoff has not elapsed", async () => {

--- a/src/forgejo-provider.ts
+++ b/src/forgejo-provider.ts
@@ -77,6 +77,7 @@ import {
   type ForgejoBindingRuntimeState,
   type ForgejoBindingRuntimeStore,
   type ForgejoRetryConfig,
+  type ForgejoRuntimeFailureProgress,
 } from "@/forgejo-runtime";
 
 export const FORGEJO_PROVIDER_VERSION = "0.1.0";
@@ -292,8 +293,10 @@ export function createForgejoSyncProvider(
       );
       logger.info("pull started", logContext);
 
+      let failureProgress: ForgejoRuntimeFailureProgress | undefined;
       try {
         loopPreventionStore.clearExpired(DEFAULT_LOOP_PREVENTION_MAX_AGE_MS);
+        const pendingCommentIssueNumbers = runtimeState.pendingCommentIssueNumbers ?? [];
 
         lastPullResult = await bootstrapForgejoIssuesToTasks({
           binding,
@@ -309,8 +312,21 @@ export function createForgejoSyncProvider(
           importClosedOnBootstrap: getImportClosedOnBootstrap(binding),
         });
 
+        const touchedIssueNumbers = [
+          ...new Set([...pendingCommentIssueNumbers, ...lastPullResult.touchedIssueNumbers]),
+        ];
+        const progressCursor = new Date().toISOString();
+        if (touchedIssueNumbers.length > 0) {
+          failureProgress = {
+            phase: "pull:comments",
+            cursor: progressCursor,
+            progressAt: progressCursor,
+            pendingCommentIssueNumbers: touchedIssueNumbers,
+          };
+        }
+
         const pullCommentsResult =
-          lastPullResult.touchedIssueNumbers.length === 0
+          touchedIssueNumbers.length === 0
             ? { comments: [], createdLinks: [] }
             : await pullComments({
                 binding,
@@ -318,7 +334,7 @@ export function createForgejoSyncProvider(
                 target,
                 itemLinkStore: linkStore,
                 commentLinkStore,
-                issueNumbers: lastPullResult.touchedIssueNumbers,
+                issueNumbers: touchedIssueNumbers,
                 since: runtimeState.lastSuccessAt ?? undefined,
                 onIssueError: ({ itemLink, error }) => {
                   const classification = classifyForgejoSyncError(error);
@@ -361,6 +377,7 @@ export function createForgejoSyncProvider(
           classification,
           logContext,
           direction: "pull",
+          progress: failureProgress,
         });
         throw error;
       }
@@ -398,6 +415,7 @@ export function createForgejoSyncProvider(
       );
       logger.info("push started", logContext);
 
+      let failureProgress: ForgejoRuntimeFailureProgress | undefined;
       try {
         loopPreventionStore.clearExpired(DEFAULT_LOOP_PREVENTION_MAX_AGE_MS);
 
@@ -446,6 +464,11 @@ export function createForgejoSyncProvider(
             closedIssue.updatedAt ?? new Date().toISOString()
           );
         }
+
+        failureProgress = {
+          phase: "push:comments",
+          progressAt: new Date().toISOString(),
+        };
 
         const pushCommentsResult = await pushComments({
           binding,
@@ -513,6 +536,7 @@ export function createForgejoSyncProvider(
           classification,
           logContext,
           direction: "push",
+          progress: failureProgress,
         });
         throw error;
       }
@@ -539,12 +563,21 @@ export function createForgejoSyncProvider(
     classification: ForgejoSyncErrorClassification;
     logContext: ForgejoSyncLogContext;
     direction: "pull" | "push";
+    progress?: ForgejoRuntimeFailureProgress;
   }): void {
     const { classification, runtimeState, bindingId, logContext } = input;
     const status = getOrCreateBindingStatus(bindingId);
 
     if (classification.retryable) {
-      runtimeStore.save(recordForgejoFailure(runtimeState, classification.summary, retryConfig));
+      runtimeStore.save(
+        recordForgejoFailure(
+          runtimeState,
+          classification.summary,
+          retryConfig,
+          new Date(),
+          input.progress
+        )
+      );
       bindingStatuses.set(
         bindingId,
         updateForgejoBindingStatusError(status, classification.summary)
@@ -553,7 +586,15 @@ export function createForgejoSyncProvider(
       return;
     }
 
-    runtimeStore.save(recordForgejoBlocked(runtimeState, classification.summary));
+    runtimeStore.save(
+      recordForgejoBlocked(
+        runtimeState,
+        classification.summary,
+        undefined,
+        new Date(),
+        input.progress
+      )
+    );
     bindingStatuses.set(
       bindingId,
       updateForgejoBindingStatusBlocked(status, classification.summary)

--- a/src/forgejo-runtime.test.ts
+++ b/src/forgejo-runtime.test.ts
@@ -30,6 +30,8 @@ describe("forgejo runtime", () => {
     expect(failed.retryAttempt).toBe(1);
     expect(failed.nextRetryAt).toBe("2026-03-12T00:00:05.000Z");
     expect(failed.lastError).toBe("rate limited");
+    expect(failed.lastFailurePhase).toBeNull();
+    expect(failed.pendingCommentIssueNumbers).toEqual([]);
 
     const succeeded = recordForgejoSuccess(
       failed,
@@ -41,6 +43,31 @@ describe("forgejo runtime", () => {
     expect(succeeded.nextRetryAt).toBeNull();
     expect(succeeded.lastError).toBeNull();
     expect(succeeded.cursor).toBe("2026-03-12T00:01:00.000Z");
+    expect(succeeded.lastFailurePhase).toBeNull();
+    expect(succeeded.pendingCommentIssueNumbers).toEqual([]);
+  });
+
+  it("records partial progress details on failure", () => {
+    const bindingId = createIntegrationBindingId("binding-1");
+    const initial = createInitialForgejoRuntimeState(bindingId);
+    const failed = recordForgejoFailure(
+      initial,
+      "comment pull failed",
+      { initialSeconds: 5, maxSeconds: 300 },
+      new Date("2026-03-12T00:00:00.000Z"),
+      {
+        phase: "pull:comments",
+        cursor: "2026-03-12T00:01:00.000Z",
+        progressAt: "2026-03-12T00:01:00.000Z",
+        pendingCommentIssueNumbers: [7, 7, 8],
+      }
+    );
+
+    expect(failed.cursor).toBe("2026-03-12T00:01:00.000Z");
+    expect(failed.lastProgressAt).toBe("2026-03-12T00:01:00.000Z");
+    expect(failed.lastFailurePhase).toBe("pull:comments");
+    expect(failed.lastFailureCursor).toBe("2026-03-12T00:01:00.000Z");
+    expect(failed.pendingCommentIssueNumbers).toEqual([7, 8]);
   });
 
   it("checks retry eligibility against nextRetryAt", () => {

--- a/src/forgejo-runtime.ts
+++ b/src/forgejo-runtime.ts
@@ -3,6 +3,12 @@ import path from "node:path";
 
 import type { IntegrationBinding } from "@todu/core";
 
+export type ForgejoRuntimeFailurePhase =
+  | "pull:issues"
+  | "pull:comments"
+  | "push:issues"
+  | "push:comments";
+
 export interface ForgejoBindingRuntimeState {
   bindingId: IntegrationBinding["id"];
   cursor: string | null;
@@ -11,6 +17,17 @@ export interface ForgejoBindingRuntimeState {
   lastError: string | null;
   lastSuccessAt: string | null;
   lastAttemptAt: string | null;
+  lastProgressAt: string | null;
+  lastFailurePhase: ForgejoRuntimeFailurePhase | null;
+  lastFailureCursor: string | null;
+  pendingCommentIssueNumbers: number[];
+}
+
+export interface ForgejoRuntimeFailureProgress {
+  phase: ForgejoRuntimeFailurePhase;
+  cursor?: string | null;
+  progressAt?: string | null;
+  pendingCommentIssueNumbers?: number[];
 }
 
 export interface ForgejoBindingRuntimeStore {
@@ -46,6 +63,10 @@ export function createInitialForgejoRuntimeState(
     lastError: null,
     lastSuccessAt: null,
     lastAttemptAt: null,
+    lastProgressAt: null,
+    lastFailurePhase: null,
+    lastFailureCursor: null,
+    pendingCommentIssueNumbers: [],
   };
 }
 
@@ -73,6 +94,10 @@ export function recordForgejoSuccess(
     lastError: null,
     lastSuccessAt: now.toISOString(),
     lastAttemptAt: now.toISOString(),
+    lastProgressAt: now.toISOString(),
+    lastFailurePhase: null,
+    lastFailureCursor: null,
+    pendingCommentIssueNumbers: [],
   };
 }
 
@@ -80,18 +105,27 @@ export function recordForgejoFailure(
   state: ForgejoBindingRuntimeState,
   error: string,
   config: ForgejoRetryConfig = DEFAULT_RETRY_CONFIG,
-  now: Date = new Date()
+  now: Date = new Date(),
+  progress?: ForgejoRuntimeFailureProgress
 ): ForgejoBindingRuntimeState {
   const nextAttempt = state.retryAttempt + 1;
   const delaySeconds = computeNextForgejoRetryDelay(nextAttempt, config);
   const nextRetryAt = new Date(now.getTime() + delaySeconds * 1000);
+  const cursor = progress && "cursor" in progress ? (progress.cursor ?? null) : state.cursor;
+  const pendingCommentIssueNumbers =
+    progress?.pendingCommentIssueNumbers ?? state.pendingCommentIssueNumbers ?? [];
 
   return {
     ...state,
+    cursor,
     retryAttempt: nextAttempt,
     nextRetryAt: nextRetryAt.toISOString(),
     lastError: error,
     lastAttemptAt: now.toISOString(),
+    lastProgressAt: progress?.progressAt ?? state.lastProgressAt ?? null,
+    lastFailurePhase: progress?.phase ?? null,
+    lastFailureCursor: progress ? cursor : state.cursor,
+    pendingCommentIssueNumbers: [...new Set(pendingCommentIssueNumbers)],
   };
 }
 
@@ -99,9 +133,10 @@ export function recordForgejoBlocked(
   state: ForgejoBindingRuntimeState,
   error: string,
   config: ForgejoRetryConfig = DEFAULT_BLOCKED_RETRY_CONFIG,
-  now: Date = new Date()
+  now: Date = new Date(),
+  progress?: ForgejoRuntimeFailureProgress
 ): ForgejoBindingRuntimeState {
-  return recordForgejoFailure(state, error, config, now);
+  return recordForgejoFailure(state, error, config, now, progress);
 }
 
 export function shouldForgejoRetry(
@@ -167,7 +202,17 @@ export function createFileForgejoBindingRuntimeStore(
         throw new Error(`Invalid Forgejo runtime store at ${storagePath}: invalid state record`);
       }
 
-      return entry as ForgejoBindingRuntimeState;
+      const state = entry as Partial<ForgejoBindingRuntimeState> & {
+        bindingId: IntegrationBinding["id"];
+      };
+
+      return {
+        ...state,
+        lastProgressAt: state.lastProgressAt ?? null,
+        lastFailurePhase: state.lastFailurePhase ?? null,
+        lastFailureCursor: state.lastFailureCursor ?? null,
+        pendingCommentIssueNumbers: state.pendingCommentIssueNumbers ?? [],
+      } as ForgejoBindingRuntimeState;
     });
   };
 


### PR DESCRIPTION
## Summary

- document Forgejo cursor and partial failure checkpoint semantics
- record runtime diagnostics for partial failures, including phase, progress checkpoint, and pending comment issues
- advance safe pull progress after issue discovery succeeds while retaining pending comment retries
- add regression coverage for stale-cursor comment retry behavior

## Verification

- npm run format
- npm run lint
- npm run typecheck
- npm test
- ./scripts/pre-pr.sh

Task: #task-62aaec3c