### PR TITLE
Clear stale Forgejo running statuses

### DIFF
--- a/src/forgejo-binding-status.ts
+++ b/src/forgejo-binding-status.ts
@@ -81,3 +81,20 @@ export function updateForgejoBindingStatusBlocked(
     updatedAt: now.toISOString(),
   };
 }
+
+export function recoverStaleForgejoBindingStatusRunning(
+  status: ForgejoBindingStatus,
+  reason = "stale running state cleared during Forgejo provider recovery",
+  now: Date = new Date()
+): ForgejoBindingStatus {
+  if (status.state !== "running") {
+    return status;
+  }
+
+  return {
+    ...status,
+    state: "error",
+    lastErrorSummary: reason,
+    updatedAt: now.toISOString(),
+  };
+}

--- a/src/forgejo-provider.test.ts
+++ b/src/forgejo-provider.test.ts
@@ -1032,6 +1032,46 @@ describe("forgejo provider runtime integration", () => {
     expect(updateCallCount).toBe(1);
   });
 
+  it("clears stale running binding status during provider recovery", async () => {
+    const issueClient = createInMemoryForgejoIssueClient();
+    issueClient.listIssues = async () => new Promise(() => undefined);
+
+    const logger = createForgejoSyncLogger();
+    const provider = createForgejoSyncProvider({
+      issueClient,
+      linkStore: createInMemoryForgejoItemLinkStore(),
+      logger,
+    });
+
+    await provider.initialize({
+      settings: {
+        baseUrl: target.baseUrl,
+        token: "secret-token",
+      },
+    });
+
+    void provider.pull(createBinding(), project);
+    await Promise.resolve();
+
+    expect(provider.getState().bindingStatuses.get(createBinding().id)?.state).toBe("running");
+
+    await provider.initialize({
+      settings: {
+        baseUrl: target.baseUrl,
+        token: "secret-token",
+      },
+    });
+
+    const status = provider.getState().bindingStatuses.get(createBinding().id);
+    expect(status).toMatchObject({
+      state: "error",
+      lastErrorSummary: "stale running state cleared during Forgejo provider recovery",
+    });
+    expect(logger.getEntries().at(-1)).toMatchObject({
+      message: "cleared stale Forgejo binding running state",
+    });
+  });
+
   it("updates binding status through running to idle on success", async () => {
     const issueClient = createInMemoryForgejoIssueClient();
     issueClient.seedIssues(target, [

--- a/src/forgejo-provider.ts
+++ b/src/forgejo-provider.ts
@@ -18,6 +18,7 @@ import {
 } from "@/forgejo-binding";
 import {
   createForgejoBindingStatus,
+  recoverStaleForgejoBindingStatusRunning,
   updateForgejoBindingStatusBlocked,
   updateForgejoBindingStatusError,
   updateForgejoBindingStatusIdle,
@@ -217,10 +218,26 @@ export function createForgejoSyncProvider(
     return parseForgejoBinding(binding);
   };
 
+  const recoverStaleRunningStatuses = (): void => {
+    for (const [bindingId, status] of bindingStatuses.entries()) {
+      const recovered = recoverStaleForgejoBindingStatusRunning(status);
+      if (recovered !== status) {
+        bindingStatuses.set(bindingId, recovered);
+        logger.warn("cleared stale Forgejo binding running state", {
+          bindingId,
+          projectId: "unknown",
+          repo: "unknown",
+          direction: "pull",
+        });
+      }
+    }
+  };
+
   return {
     name: FORGEJO_PROVIDER_NAME,
     version: FORGEJO_PROVIDER_VERSION,
     async initialize(config: SyncProviderConfig): Promise<void> {
+      recoverStaleRunningStatuses();
       settings = loadForgejoProviderSettings(config);
       if (!options.issueClient) {
         issueClient = createHttpForgejoIssueClient(settings.token, {
@@ -250,6 +267,7 @@ export function createForgejoSyncProvider(
       }
     },
     async shutdown(): Promise<void> {
+      recoverStaleRunningStatuses();
       settings = null;
       lastPullResult = null;
       lastPushResult = null;


### PR DESCRIPTION
## Summary

- recover stale Forgejo binding statuses stuck in running by moving them to error
- run stale-running recovery on provider initialize and shutdown
- add regression coverage proving recovery does not preserve running as active state

## Verification

- npm run format
- npm run lint
- npm run typecheck
- npm test
- ./scripts/pre-pr.sh

Task: #task-cf3ce86b