### PR TITLE
Bound Forgejo comment pagination

### DIFF
--- a/src/forgejo-http-client.test.ts
+++ b/src/forgejo-http-client.test.ts
@@ -101,6 +101,22 @@ describe("forgejo http client", () => {
     expect(requests).toHaveLength(2);
   });
 
+  it("fails safely when comment pagination exceeds bounded item processing", async () => {
+    let nextId = 1;
+    const requests: string[] = [];
+    const fetchImpl: typeof fetch = async (url) => {
+      requests.push(String(url));
+      return createJsonResponse(Array.from({ length: 100 }, () => createApiComment(nextId++)));
+    };
+
+    const client = createHttpForgejoIssueClient("token", { fetchImpl });
+
+    await expect(client.listComments(target, 45)).rejects.toThrow(
+      "Forgejo pagination exceeded 5000 items"
+    );
+    expect(requests).toHaveLength(51);
+  });
+
   it("deduplicates comments by id across partially overlapping pages", async () => {
     const pages = [
       Array.from({ length: 100 }, (_, index) => createApiComment(index + 1)),

--- a/src/forgejo-http-client.ts
+++ b/src/forgejo-http-client.ts
@@ -50,7 +50,13 @@ interface ForgejoApiComment {
 
 interface ListAllPagesOptions<T> {
   itemKey?: (item: T) => number | string;
+  maxItems?: number;
+  maxPages?: number;
 }
+
+const PAGE_LIMIT = 100;
+const DEFAULT_MAX_PAGES = 1_000;
+const DEFAULT_MAX_ITEMS = 10_000;
 
 function normalizeLabels(labels: ForgejoApiIssue["labels"]): string[] {
   return labels.map((label) => (typeof label === "string" ? label : label.name));
@@ -208,9 +214,15 @@ export function createHttpForgejoIssueClient(
     const seenItemKeys = new Set<string>();
     const seenPageSignatures = new Set<string>();
     let page = 1;
-    const limit = 100;
+    const limit = PAGE_LIMIT;
+    const maxPages = options.maxPages ?? DEFAULT_MAX_PAGES;
+    const maxItems = options.maxItems ?? DEFAULT_MAX_ITEMS;
 
     for (;;) {
+      if (page > maxPages) {
+        throw new Error(`Forgejo pagination exceeded ${maxPages} pages for ${path}`);
+      }
+
       const separator = path.includes("?") ? "&" : "?";
       const items = await request<T[]>(
         target,
@@ -232,6 +244,9 @@ export function createHttpForgejoIssueClient(
         if (!itemKey) {
           results.push(item);
           addedCount += 1;
+          if (results.length > maxItems) {
+            throw new Error(`Forgejo pagination exceeded ${maxItems} items for ${path}`);
+          }
           continue;
         }
 
@@ -243,6 +258,10 @@ export function createHttpForgejoIssueClient(
         seenItemKeys.add(key);
         results.push(item);
         addedCount += 1;
+
+        if (results.length > maxItems) {
+          throw new Error(`Forgejo pagination exceeded ${maxItems} items for ${path}`);
+        }
       }
 
       if (items.length < limit || (itemKey && items.length > 0 && addedCount === 0)) {
@@ -376,6 +395,7 @@ export function createHttpForgejoIssueClient(
 
       const rawComments = await listAllPages<ForgejoApiComment>(target, path, {
         itemKey: (comment) => comment.id,
+        maxItems: 5_000,
       });
       return rawComments.map((rawComment) => mapApiComment(target, issueNumber, rawComment));
     },

--- a/src/forgejo-provider-hardening.test.ts
+++ b/src/forgejo-provider-hardening.test.ts
@@ -538,6 +538,47 @@ describe("provider push failure handling", () => {
     expect(linkStore.getByIssueNumber(createBinding().id, 1)).not.toBeNull();
   });
 
+  it("records actionable error status when bounded comment processing fails", async () => {
+    const issueClient = createInMemoryForgejoIssueClient();
+    issueClient.seedIssues(target, [
+      {
+        number: 7,
+        externalId: "https://code.example.com/acme/roadmap#7",
+        title: "Issue seven",
+        state: "open",
+        labels: ["status:active"],
+        assignees: [],
+        createdAt: "2026-03-12T00:00:00.000Z",
+        updatedAt: "2026-03-12T01:00:00.000Z",
+      },
+    ]);
+    issueClient.listComments = async () => {
+      throw new Error(
+        "Forgejo pagination exceeded 5000 items for /repos/acme/roadmap/issues/7/comments"
+      );
+    };
+
+    const runtimeStore = createInMemoryForgejoBindingRuntimeStore();
+    const provider = await initProvider({
+      issueClient,
+      linkStore: createInMemoryForgejoItemLinkStore(),
+      runtimeStore,
+    });
+
+    await expect(provider.pull(createBinding(), project)).rejects.toThrow(
+      "Forgejo pagination exceeded 5000 items"
+    );
+
+    const status = provider.getState().bindingStatuses.get(createBinding().id);
+    expect(status).toMatchObject({
+      state: "error",
+      lastErrorSummary: expect.stringContaining("Forgejo pagination exceeded 5000 items"),
+    });
+    expect(runtimeStore.get(createBinding().id)?.lastError).toContain(
+      "Forgejo pagination exceeded 5000 items"
+    );
+  });
+
   it("records failure state when push throws", async () => {
     const issueClient = createInMemoryForgejoIssueClient();
     issueClient.createIssue = async () => {


### PR DESCRIPTION
## Summary

- add max-page and max-item safeguards to Forgejo HTTP pagination
- cap comment pagination at 5,000 unique comments per request
- surface bounded comment processing failures through provider runtime and binding status
- add regression coverage for large repeated comment processing bounds

## Verification

- npm run format
- npm run lint
- npm run typecheck
- npm test
- ./scripts/pre-pr.sh

Task: #task-8ac7d91d