### PR TITLE
Fix missed Forgejo comment-only changes

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -458,7 +458,7 @@ Each polling cycle processes the binding according to strategy:
 - list issues updated since the last successful checkpoint
 - refresh linked item field state
 - discover newly created open issues
-- list comments for changed linked issues, optionally constrained by a comment `since` checkpoint when deletion detection is not required
+- list comments for linked issues using a comment `since` checkpoint, so comment-only changes do not depend on issue `updated_at` behavior
 - mirror comment creates/edits into todu
 - normalize reserved labels/state if needed
 

--- a/docs/SMOKE-TEST.md
+++ b/docs/SMOKE-TEST.md
@@ -105,6 +105,10 @@ Create an issue directly in the Forgejo UI. Wait one sync interval. Verify:
 - a new task appears in the dev project
 - title, status, priority, and labels are imported
 
+### Pull: comment-only sync
+
+After an issue is linked, add or edit a comment directly in Forgejo without changing the issue title, body, state, labels, or assignees. Wait one sync interval. Verify the comment is imported or updated in todu. This confirms comment polling does not rely on Forgejo updating the issue `updated_at` timestamp for comment-only changes.
+
 ### Pull: issue close
 
 Close an issue in Forgejo. Verify the todu task status becomes `done`.

--- a/src/forgejo-provider.test.ts
+++ b/src/forgejo-provider.test.ts
@@ -502,7 +502,7 @@ describe("forgejo provider runtime integration", () => {
     ]);
   });
 
-  it("only checks touched linked issues for incremental comments", async () => {
+  it("checks linked issue comments during incremental pulls with a since filter", async () => {
     const issueClient = createInMemoryForgejoIssueClient();
     issueClient.seedIssues(target, [
       {
@@ -596,10 +596,13 @@ describe("forgejo provider runtime integration", () => {
 
     await provider.pull(createBinding(), project);
 
-    expect(listCommentsCalls).toEqual([{ issueNumber: 7, since: expect.any(String) }]);
+    expect(listCommentsCalls).toEqual([
+      { issueNumber: 7, since: expect.any(String) },
+      { issueNumber: 8, since: expect.any(String) },
+    ]);
   });
 
-  it("skips comment fetches when no issues are touched by the current pull", async () => {
+  it("imports comment-only changes when the issue timestamp is unchanged", async () => {
     const issueClient = createInMemoryForgejoIssueClient();
     issueClient.seedIssues(target, [
       {
@@ -640,16 +643,43 @@ describe("forgejo provider runtime integration", () => {
 
     await provider.pull(createBinding(), project);
 
-    const listCommentsCalls: number[] = [];
-    issueClient.listComments = async (_bindingTarget, issueNumber) => {
-      listCommentsCalls.push(issueNumber);
-      throw new Error("comments should not be fetched when no issues are touched");
+    const commentUpdatedAtAfterFirstPull = new Date(Date.now() + 60_000).toISOString();
+    issueClient.seedComments(target, 7, [
+      {
+        id: 11,
+        issueNumber: 7,
+        body: "Comment seven",
+        author: "alice",
+        createdAt: "2026-03-12T01:30:00.000Z",
+        updatedAt: "2026-03-12T01:30:00.000Z",
+      },
+      {
+        id: 12,
+        issueNumber: 7,
+        body: "Comment-only update",
+        author: "alice",
+        createdAt: commentUpdatedAtAfterFirstPull,
+        updatedAt: commentUpdatedAtAfterFirstPull,
+      },
+    ]);
+
+    const listIssuesCalls: Array<{ since?: string }> = [];
+    const originalListIssues = issueClient.listIssues.bind(issueClient);
+    issueClient.listIssues = async (bindingTarget, options) => {
+      listIssuesCalls.push({ since: options?.since });
+      return originalListIssues(bindingTarget, options);
     };
 
     const result = await provider.pull(createBinding(), project);
 
-    expect(result.comments).toEqual([]);
-    expect(listCommentsCalls).toEqual([]);
+    expect(listIssuesCalls).toEqual([{ since: expect.any(String) }]);
+    expect(result.tasks).toEqual([]);
+    expect(result.comments).toEqual([
+      expect.objectContaining({
+        externalId: "12",
+        body: expect.stringContaining("Comment-only update"),
+      }),
+    ]);
   });
 
   it("records failure in runtime store when pull throws", async () => {
@@ -784,7 +814,8 @@ describe("forgejo provider runtime integration", () => {
     const finalResult = await provider.pull(binding, project);
 
     expect(finalResult.comments).toEqual([]);
-    expect(listCommentsCalls).toHaveLength(commentCallsAfterRetry);
+    expect(listCommentsCalls).toHaveLength(commentCallsAfterRetry + 1);
+    expect(listCommentsCalls.at(-1)).toBe(7);
   });
 
   it("skips pull when retry backoff has not elapsed", async () => {

--- a/src/forgejo-provider.ts
+++ b/src/forgejo-provider.ts
@@ -330,21 +330,29 @@ export function createForgejoSyncProvider(
           importClosedOnBootstrap: getImportClosedOnBootstrap(binding),
         });
 
-        const touchedIssueNumbers = [
-          ...new Set([...pendingCommentIssueNumbers, ...lastPullResult.touchedIssueNumbers]),
+        const commentSince = runtimeState.lastSuccessAt ?? undefined;
+        const linkedCommentIssueNumbers = commentSince
+          ? linkStore.list(binding.id).map((itemLink) => itemLink.issueNumber)
+          : [];
+        const commentIssueNumbers = [
+          ...new Set([
+            ...pendingCommentIssueNumbers,
+            ...lastPullResult.touchedIssueNumbers,
+            ...linkedCommentIssueNumbers,
+          ]),
         ];
         const progressCursor = new Date().toISOString();
-        if (touchedIssueNumbers.length > 0) {
+        if (commentIssueNumbers.length > 0) {
           failureProgress = {
             phase: "pull:comments",
             cursor: progressCursor,
             progressAt: progressCursor,
-            pendingCommentIssueNumbers: touchedIssueNumbers,
+            pendingCommentIssueNumbers: commentIssueNumbers,
           };
         }
 
         const pullCommentsResult =
-          touchedIssueNumbers.length === 0
+          commentIssueNumbers.length === 0
             ? { comments: [], createdLinks: [] }
             : await pullComments({
                 binding,
@@ -352,8 +360,8 @@ export function createForgejoSyncProvider(
                 target,
                 itemLinkStore: linkStore,
                 commentLinkStore,
-                issueNumbers: touchedIssueNumbers,
-                since: runtimeState.lastSuccessAt ?? undefined,
+                issueNumbers: commentIssueNumbers,
+                since: commentSince,
                 onIssueError: ({ itemLink, error }) => {
                   const classification = classifyForgejoSyncError(error);
                   if (classification.kind !== "not-found") {


### PR DESCRIPTION
## Summary
- pull comments for linked Forgejo issues with a since checkpoint during incremental sync
- add regression coverage for comment-only changes when issue updated_at is unchanged
- document that pull comment polling does not rely on issue updated_at behavior

## Verification
- npm run format
- npm run lint
- npm run typecheck
- npm test
- npm run build

Task: #task-48951177